### PR TITLE
Add setup script to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ apt update && apt install -y pkg-config cmake build-essential
 pip install .
 ```
 
+### Troubleshooting
+* If using VSCode or Cursor you will also need to set the VSCode notebook environment to `circuit-tracer` through their interface.
+* If you get a kernal crash switch to a different GPU, gemma models appear to have issues on running on A100 pcie cards
+* The demos won't run on Apple M series (mps) GPUs.
+
 ## Demos
 We include some demos showing how to use our library in the `demos` folder. The main demo is [`demos/circuit_tracing_tutorial.ipynb`](https://github.com/safety-research/circuit-tracer/blob/main/demos/circuit_tracing_tutorial.ipynb), which replicates two of the findings from [this paper](https://transformer-circuits.pub/2025/attribution-graphs/biology.html) using Gemma 2 (2B). All demos except for the Llama demo can be run on Colab.
 


### PR DESCRIPTION
## What
Adds a setup script that performs all necessary setup for the project
Adds a troubleshooting section to readme.

## Why
Make it easier for people unfamiliar with this project, virtual environments or AI Safety research to set the project up. (We used this project as part of an AISafety course).

## Testing

- [ ] Modify setup script to use `circuit-tracer2` if your current environment is named `circuit-tracer`
- [ ] Run setup script within a directory that doesn't currently contain a circuit-tracer directory.
- [ ] Switch VSCode's notebook environment to your new env.
- [ ] Run `circuit-tracing-tutorial.ipynb