### PR TITLE
feat: Subgraph scores and notebook

### DIFF
--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -345,7 +345,7 @@ def compute_subgraph_scores(
     # Find matching indices in selected_features
     for i in range(n_features):
         active_idx = graph.selected_features[i].item()
-        layer, pos, feat_idx = graph.active_features[active_idx].tolist()
+        layer, pos, feat_idx = graph.active_features[active_idx].tolist() # type: ignore
 
         if (layer, pos, feat_idx) in target_features:
             subgraph_feature_mask[i] = True

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -345,7 +345,7 @@ def compute_subgraph_scores(
     # Find matching indices in selected_features
     for i in range(n_features):
         active_idx = graph.selected_features[i].item()
-        layer, pos, feat_idx = graph.active_features[active_idx].tolist() # type: ignore
+        layer, pos, feat_idx = graph.active_features[active_idx].tolist()  # type: ignore
 
         if (layer, pos, feat_idx) in target_features:
             subgraph_feature_mask[i] = True

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -2,7 +2,6 @@ from typing import NamedTuple
 
 import torch
 from transformer_lens import HookedTransformerConfig
-from circuit_tracer.utils.decode_url_features import Feature
 
 
 class Graph:
@@ -341,7 +340,7 @@ def compute_graph_scores(graph: Graph) -> tuple[float, float]:
 
 def compute_subgraph_scores(
     graph: Graph,
-    pinned_features: list[Feature],
+    pinned_features: list[tuple[int, int, int]],  # (layer, pos, feature_idx)
 ) -> tuple[float, float]:
     """Compute metrics for evaluating a subgraph by treating pruned features as errors.
 
@@ -352,8 +351,8 @@ def compute_subgraph_scores(
     Args:
         graph: The computation graph (can be original or pruned) containing nodes for
                features, errors, tokens, and logits, along with their connections.
-        pinned_features: List of Features to include in the subgraph. Features not
-                        in this list are treated as pruned/errors.
+        pinned_features: List of (layer, pos, feature_idx) tuples to include in the subgraph.
+                        Features not in this list are treated as pruned/errors.
 
     Returns:
         tuple[float, float]: A tuple containing:
@@ -376,9 +375,9 @@ def compute_subgraph_scores(
         layer, pos, feat_idx = graph.active_features[graph.selected_features[feature_idx]].tolist()
         for pinned_feature in pinned_features:
             if (
-                pinned_feature.layer == layer
-                and pinned_feature.pos == pos
-                and pinned_feature.feature_idx == feat_idx
+                pinned_feature[0] == layer
+                and pinned_feature[1] == pos
+                and pinned_feature[2] == feat_idx
             ):
                 subgraph_feature_mask[feature_idx] = True
                 break

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -248,6 +248,47 @@ def prune_graph(
     return PruneResult(node_mask, edge_mask, final_scores)
 
 
+def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor) -> Graph:
+    """Create a pruned version of the graph by applying node and edge masks.
+
+    Args:
+        graph: The original graph
+        node_mask: Boolean tensor indicating which nodes to keep
+        edge_mask: Boolean tensor indicating which edges to keep
+
+    Returns:
+        A new Graph object containing only the pruned nodes and edges
+
+    Note:
+        The pruned graph maintains the same structure as the original graph
+        (same dimensions for adjacency matrix, selected_features, etc.) but
+        with removed nodes/edges represented as zeros in the adjacency matrix.
+        This ensures that functions like compute_graph_scores can correctly
+        interpret the graph structure.
+    """
+    # Apply masks to adjacency matrix - this is the ONLY change we make
+    # All removed nodes/edges are represented as zeros
+    pruned_adjacency = graph.adjacency_matrix.clone()
+    pruned_adjacency[~node_mask] = 0
+    pruned_adjacency[:, ~node_mask] = 0
+    pruned_adjacency = pruned_adjacency * edge_mask
+
+    # Keep all other fields unchanged to preserve the graph structure
+    # The pruning is represented entirely by the zeros in the adjacency matrix
+    return Graph(
+        input_string=graph.input_string,
+        input_tokens=graph.input_tokens,
+        active_features=graph.active_features,
+        adjacency_matrix=pruned_adjacency,
+        cfg=graph.cfg,
+        logit_tokens=graph.logit_tokens,
+        logit_probabilities=graph.logit_probabilities,
+        selected_features=graph.selected_features,
+        activation_values=graph.activation_values,
+        scan=graph.scan,
+    )
+
+
 def compute_graph_scores(graph: Graph) -> tuple[float, float]:
     """Compute metrics for evaluating how well the graph captures the model's computation.
     This function calculates two complementary scores that measure how much of the model's

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -342,8 +342,6 @@ def compute_graph_scores(graph: Graph) -> tuple[float, float]:
 def compute_subgraph_scores(
     graph: Graph,
     pinned_features: list[Feature],
-    node_mask: torch.Tensor,
-    edge_mask: torch.Tensor,
 ) -> tuple[float, float]:
     """Compute metrics for evaluating a subgraph by treating pruned features as errors.
 
@@ -352,12 +350,10 @@ def compute_subgraph_scores(
     then computes replacement and completeness scores using the modified adjacency matrix.
 
     Args:
-        graph: The original (unpruned) computation graph containing nodes for features,
-               errors, tokens, and logits, along with their connections.
+        graph: The computation graph (can be original or pruned) containing nodes for
+               features, errors, tokens, and logits, along with their connections.
         pinned_features: List of Features to include in the subgraph. Features not
                         in this list are treated as pruned/errors.
-        node_mask: Boolean tensor from prune_graph indicating which nodes survived pruning.
-        edge_mask: Boolean tensor from prune_graph indicating which edges survived pruning.
 
     Returns:
         tuple[float, float]: A tuple containing:
@@ -396,23 +392,16 @@ def compute_subgraph_scores(
     error_end = error_start + n_tokens * n_layers
     token_end = error_end + n_tokens
 
-    # Start with the original adjacency matrix (before pruning)
+    # Start with the graph's adjacency matrix (which may already be pruned)
     modified_adjacency = graph.adjacency_matrix.clone()
 
-    # For features that survived initial pruning but are NOT in the subgraph,
-    # merge their edges with the corresponding error nodes
+    # For features that are NOT in the subgraph, merge their edges with error nodes
     for feature_idx in range(n_features):
-        # Check if this feature survived the initial pruning
-        if not node_mask[feature_idx]:
-            # Feature was already pruned in initial pruning, skip it
-            # (its contribution is already captured in the error nodes)
-            continue
-
         if subgraph_feature_mask[feature_idx].item():
             # Feature is pinned (included in subgraph), keep it
             pass
         else:
-            # Feature survived initial pruning but is NOT in the subgraph
+            # Feature is active but NOT in the subgraph
             # Merge its edges into the corresponding error node
             layer, pos, _ = graph.active_features[graph.selected_features[feature_idx]]
 
@@ -427,12 +416,6 @@ def compute_subgraph_scores(
             # Zero out the pruned feature's edges (both incoming and outgoing)
             modified_adjacency[feature_idx, :] = 0
             modified_adjacency[:, feature_idx] = 0
-
-    # Now apply the initial pruning to the modified adjacency matrix
-    # (for nodes that didn't survive initial pruning and weren't merged above)
-    modified_adjacency[~node_mask] = 0
-    modified_adjacency[:, ~node_mask] = 0
-    modified_adjacency = modified_adjacency * edge_mask
 
     # Compute scores using the modified adjacency matrix
     logit_weights = torch.zeros(modified_adjacency.shape[0], device=modified_adjacency.device)

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -296,6 +296,7 @@ def compute_graph_scores(graph: Graph) -> tuple[float, float]:
 
     return replacement_score.item(), completeness_score.item()
 
+
 def compute_subgraph_scores(
     graph: Graph, node_ids: list[str], node_mask: torch.Tensor, edge_mask: torch.Tensor
 ) -> tuple[float, float]:
@@ -328,24 +329,24 @@ def compute_subgraph_scores(
 
     # Convert node_ids to a subgraph feature mask
     subgraph_feature_mask = torch.zeros(n_features, dtype=torch.bool)
-    
+
     # Parse node_ids to extract (layer, pos, feat_idx)
     target_features = set()
     for node_id in node_ids:
-        parts = node_id.split('_')
+        parts = node_id.split("_")
         # Feature nodes have format "layer_featidx_pos"
         # Skip non-feature nodes (token: "E_vocab_pos", logit: where layer > n_layers)
-        if len(parts) == 3 and not node_id.startswith('E_'):
+        if len(parts) == 3 and not node_id.startswith("E_"):
             layer, feat_idx, pos = int(parts[0]), int(parts[1]), int(parts[2])
             # Only consider if it's a valid layer (not a logit node)
             if layer < n_layers:
                 target_features.add((layer, pos, feat_idx))
-    
+
     # Find matching indices in selected_features
     for i in range(n_features):
         active_idx = graph.selected_features[i].item()
         layer, pos, feat_idx = graph.active_features[active_idx].tolist()
-        
+
         if (layer, pos, feat_idx) in target_features:
             subgraph_feature_mask[i] = True
 
@@ -369,7 +370,7 @@ def compute_subgraph_scores(
             # Feature was already pruned in initial pruning, skip it
             # (its contribution is already captured in the error nodes)
             continue
-            
+
         if subgraph_feature_mask[feature_idx].item():
             # Feature is pinned (included in subgraph), keep it
             pass
@@ -397,20 +398,18 @@ def compute_subgraph_scores(
     modified_adjacency = modified_adjacency * edge_mask
 
     # Compute scores using the modified adjacency matrix
-    logit_weights = torch.zeros(
-        modified_adjacency.shape[0], device=modified_adjacency.device
-    )
+    logit_weights = torch.zeros(modified_adjacency.shape[0], device=modified_adjacency.device)
     logit_weights[-n_logits:] = graph.logit_probabilities
 
     normalized_matrix = normalize_matrix(modified_adjacency)
     node_influence = compute_influence(normalized_matrix, logit_weights)
-    
+
     token_influence = node_influence[error_end:token_end].sum()
     error_influence = node_influence[error_start:error_end].sum()
     replacement_score = token_influence / (token_influence + error_influence)
     non_error_fractions = 1 - normalized_matrix[:, error_start:error_end].sum(dim=-1)
-    
-    output_influence = node_influence + logit_weights    
+
+    output_influence = node_influence + logit_weights
     completeness_score = (non_error_fractions * output_influence).sum() / output_influence.sum()
 
     return replacement_score.item(), completeness_score.item()

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -247,8 +247,14 @@ def prune_graph(
     return PruneResult(node_mask, edge_mask, final_scores)
 
 
-def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor) -> Graph:
-    """Create a pruned version of the graph by applying node and edge masks.
+def create_pruned_graph(
+    graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor
+) -> Graph:
+    """Create a pruned graph variant that removes pruned feature nodes entirely.
+
+    Error/token/logit nodes are retained (with edges
+    masked/zeroed as needed) so that downstream utilities relying on their
+    counts and order still work.
 
     Args:
         graph: The original graph
@@ -256,24 +262,38 @@ def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.
         edge_mask: Boolean tensor indicating which edges to keep
 
     Returns:
-        A new Graph object containing only the pruned nodes and edges
-
-    Note:
-        The pruned graph maintains the same structure as the original graph
-        (same dimensions for adjacency matrix, selected_features, etc.) but
-        with removed nodes/edges represented as zeros in the adjacency matrix.
-        This ensures that functions like compute_graph_scores can correctly
-        interpret the graph structure.
+        A new Graph object in which pruned features have been removed from the
+        adjacency matrix and feature metadata, while other node types are kept.
     """
-    # Apply masks to adjacency matrix - this is the ONLY change we make
-    # All removed nodes/edges are represented as zeros
-    pruned_adjacency = graph.adjacency_matrix.clone()
-    pruned_adjacency[~node_mask] = 0
-    pruned_adjacency[:, ~node_mask] = 0
-    pruned_adjacency = pruned_adjacency * edge_mask
 
-    # Keep all other fields unchanged to preserve the graph structure
-    # The pruning is represented entirely by the zeros in the adjacency matrix
+    # Dimensions and boundaries
+    n_tokens = len(graph.input_tokens)
+    n_logits = len(graph.logit_tokens)
+    n_layers = graph.cfg.n_layers
+    n_features = len(graph.selected_features)
+    _ = n_tokens, n_logits, n_layers  # silence linters for unused locals
+
+    # First apply masks, zeroing pruned nodes/edges
+    masked_adjacency = graph.adjacency_matrix.clone()
+    masked_adjacency[~node_mask] = 0
+    masked_adjacency[:, ~node_mask] = 0
+    masked_adjacency = masked_adjacency * edge_mask
+
+    # Only remove feature nodes (first n_features). Keep errors/tokens/logits.
+    kept_feature_mask = node_mask[:n_features]
+    keep_mask = torch.ones_like(node_mask, dtype=torch.bool, device=node_mask.device)
+    keep_mask[:n_features] = kept_feature_mask
+
+    pruned_adjacency = masked_adjacency[keep_mask][:, keep_mask]
+
+    # Update feature metadata to align with removed features
+    # activation_values is aligned to active_features, while the first n_features
+    # nodes correspond to selected_features in order. So map first, then mask.
+    pruned_selected_features = graph.selected_features[kept_feature_mask]
+    pruned_activation_values = graph.activation_values[graph.selected_features][
+        kept_feature_mask
+    ]
+
     return Graph(
         input_string=graph.input_string,
         input_tokens=graph.input_tokens,
@@ -282,8 +302,8 @@ def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.
         cfg=graph.cfg,
         logit_tokens=graph.logit_tokens,
         logit_probabilities=graph.logit_probabilities,
-        selected_features=graph.selected_features,
-        activation_values=graph.activation_values,
+        selected_features=pruned_selected_features,
+        activation_values=pruned_activation_values,
         scan=graph.scan,
     )
 

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -297,7 +297,7 @@ def compute_graph_scores(graph: Graph) -> tuple[float, float]:
     return replacement_score.item(), completeness_score.item()
 
 def compute_subgraph_scores(
-    graph: Graph, node_ids: list[str]
+    graph: Graph, node_ids: list[str], node_mask: torch.Tensor, edge_mask: torch.Tensor
 ) -> tuple[float, float]:
     """Compute metrics for evaluating a subgraph by treating pruned features as errors.
 
@@ -306,12 +306,13 @@ def compute_subgraph_scores(
     then computes replacement and completeness scores using the modified adjacency matrix.
 
     Args:
-        graph: A pruned computation graph (as created by create_pruned_graph) containing
-               only the nodes that survived initial pruning. The graph contains nodes for
-               features, errors, tokens, and logits, along with their connections.
+        graph: The original (unpruned) computation graph containing nodes for features,
+               errors, tokens, and logits, along with their connections.
         node_ids: List of node_id strings for feature nodes to include in the subgraph.
                  Format: "layer_featidx_pos" (e.g., "5_123_10" for layer 5, feature 123,
                  position 10). Features not in this list are treated as pruned/errors.
+        node_mask: Boolean tensor from prune_graph indicating which nodes survived pruning.
+        edge_mask: Boolean tensor from prune_graph indicating which edges survived pruning.
 
     Returns:
         tuple[float, float]: A tuple containing:
@@ -322,7 +323,7 @@ def compute_subgraph_scores(
     """
     n_logits = len(graph.logit_tokens)
     n_tokens = len(graph.input_tokens)
-    n_features = len(graph.selected_features)  # Only features in the pruned graph
+    n_features = len(graph.selected_features)
     n_layers = graph.cfg.n_layers
 
     # Convert node_ids to a subgraph feature mask
@@ -348,8 +349,8 @@ def compute_subgraph_scores(
         if (layer, pos, feat_idx) in target_features:
             subgraph_feature_mask[i] = True
 
-    # In the pruned graph's adjacency matrix:
-    # - First n_features rows/cols are the surviving feature nodes
+    # In the adjacency matrix:
+    # - First n_features rows/cols are feature nodes
     # - Next n_tokens * n_layers rows/cols are error nodes (one per layer per token)
     # - Next n_tokens rows/cols are token embedding nodes
     # - Last n_logits rows/cols are logit nodes
@@ -357,18 +358,24 @@ def compute_subgraph_scores(
     error_end = error_start + n_tokens * n_layers
     token_end = error_end + n_tokens
 
-    # Create modified adjacency matrix
+    # Start with the original adjacency matrix (before pruning)
     modified_adjacency = graph.adjacency_matrix.clone()
 
-    # For each pruned feature, merge its edges with the corresponding error node
+    # For features that survived initial pruning but are NOT in the subgraph,
+    # merge their edges with the corresponding error nodes
     for feature_idx in range(n_features):
+        # Check if this feature survived the initial pruning
+        if not node_mask[feature_idx]:
+            # Feature was already pruned in initial pruning, skip it
+            # (its contribution is already captured in the error nodes)
+            continue
+            
         if subgraph_feature_mask[feature_idx].item():
-            # Feature is pinned (included in subgraph)
+            # Feature is pinned (included in subgraph), keep it
             pass
         else:
-            # Feature is pruned (not included in subgraph)
-            # Get the layer and position of this feature from active_features
-            # graph.selected_features[feature_idx] is an index into active_features
+            # Feature survived initial pruning but is NOT in the subgraph
+            # Merge its edges into the corresponding error node
             layer, pos, _ = graph.active_features[graph.selected_features[feature_idx]]
 
             # Calculate the corresponding error node index
@@ -382,6 +389,12 @@ def compute_subgraph_scores(
             # Zero out the pruned feature's edges (both incoming and outgoing)
             modified_adjacency[feature_idx, :] = 0
             modified_adjacency[:, feature_idx] = 0
+
+    # Now apply the initial pruning to the modified adjacency matrix
+    # (for nodes that didn't survive initial pruning and weren't merged above)
+    modified_adjacency[~node_mask] = 0
+    modified_adjacency[:, ~node_mask] = 0
+    modified_adjacency = modified_adjacency * edge_mask
 
     # Compute scores using the modified adjacency matrix
     logit_weights = torch.zeros(

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -247,9 +247,7 @@ def prune_graph(
     return PruneResult(node_mask, edge_mask, final_scores)
 
 
-def create_pruned_graph(
-    graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor
-) -> Graph:
+def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor) -> Graph:
     """Create a pruned graph variant that removes pruned feature nodes entirely.
 
     Error/token/logit nodes are retained (with edges
@@ -290,9 +288,7 @@ def create_pruned_graph(
     # activation_values is aligned to active_features, while the first n_features
     # nodes correspond to selected_features in order. So map first, then mask.
     pruned_selected_features = graph.selected_features[kept_feature_mask]
-    pruned_activation_values = graph.activation_values[graph.selected_features][
-        kept_feature_mask
-    ]
+    pruned_activation_values = graph.activation_values[graph.selected_features][kept_feature_mask]
 
     return Graph(
         input_string=graph.input_string,

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -2,6 +2,7 @@ from typing import NamedTuple
 
 import torch
 from transformer_lens import HookedTransformerConfig
+from circuit_tracer.utils.decode_url_features import Feature
 
 
 class Graph:
@@ -298,7 +299,10 @@ def compute_graph_scores(graph: Graph) -> tuple[float, float]:
 
 
 def compute_subgraph_scores(
-    graph: Graph, node_ids: list[str], node_mask: torch.Tensor, edge_mask: torch.Tensor
+    graph: Graph,
+    pinned_features: list[Feature],
+    node_mask: torch.Tensor,
+    edge_mask: torch.Tensor,
 ) -> tuple[float, float]:
     """Compute metrics for evaluating a subgraph by treating pruned features as errors.
 
@@ -309,9 +313,8 @@ def compute_subgraph_scores(
     Args:
         graph: The original (unpruned) computation graph containing nodes for features,
                errors, tokens, and logits, along with their connections.
-        node_ids: List of node_id strings for feature nodes to include in the subgraph.
-                 Format: "layer_featidx_pos" (e.g., "5_123_10" for layer 5, feature 123,
-                 position 10). Features not in this list are treated as pruned/errors.
+        pinned_features: List of Features to include in the subgraph. Features not
+                        in this list are treated as pruned/errors.
         node_mask: Boolean tensor from prune_graph indicating which nodes survived pruning.
         edge_mask: Boolean tensor from prune_graph indicating which edges survived pruning.
 
@@ -327,28 +330,21 @@ def compute_subgraph_scores(
     n_features = len(graph.selected_features)
     n_layers = graph.cfg.n_layers
 
-    # Convert node_ids to a subgraph feature mask
-    subgraph_feature_mask = torch.zeros(n_features, dtype=torch.bool)
+    # Create a boolean mask for features in the subgraph
+    subgraph_feature_mask = torch.zeros(
+        n_features, dtype=torch.bool, device=graph.active_features.device
+    )
 
-    # Parse node_ids to extract (layer, pos, feat_idx)
-    target_features = set()
-    for node_id in node_ids:
-        parts = node_id.split("_")
-        # Feature nodes have format "layer_featidx_pos"
-        # Skip non-feature nodes (token: "E_vocab_pos", logit: where layer > n_layers)
-        if len(parts) == 3 and not node_id.startswith("E_"):
-            layer, feat_idx, pos = int(parts[0]), int(parts[1]), int(parts[2])
-            # Only consider if it's a valid layer (not a logit node)
-            if layer < n_layers:
-                target_features.add((layer, pos, feat_idx))
-
-    # Find matching indices in selected_features
-    for i in range(n_features):
-        active_idx = graph.selected_features[i].item()
-        layer, pos, feat_idx = graph.active_features[active_idx].tolist()  # type: ignore
-
-        if (layer, pos, feat_idx) in target_features:
-            subgraph_feature_mask[i] = True
+    for feature_idx in range(n_features):
+        layer, pos, feat_idx = graph.active_features[graph.selected_features[feature_idx]].tolist()
+        for pinned_feature in pinned_features:
+            if (
+                pinned_feature.layer == layer
+                and pinned_feature.pos == pos
+                and pinned_feature.feature_idx == feat_idx
+            ):
+                subgraph_feature_mask[feature_idx] = True
+                break
 
     # In the adjacency matrix:
     # - First n_features rows/cols are feature nodes

--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -295,3 +295,109 @@ def compute_graph_scores(graph: Graph) -> tuple[float, float]:
     completeness_score = (non_error_fractions * output_influence).sum() / output_influence.sum()
 
     return replacement_score.item(), completeness_score.item()
+
+def compute_subgraph_scores(
+    graph: Graph, node_ids: list[str]
+) -> tuple[float, float]:
+    """Compute metrics for evaluating a subgraph by treating pruned features as errors.
+
+    This function treats features not included in the subgraph as error nodes by merging
+    their edge weights with the corresponding error nodes (based on layer and position),
+    then computes replacement and completeness scores using the modified adjacency matrix.
+
+    Args:
+        graph: A pruned computation graph (as created by create_pruned_graph) containing
+               only the nodes that survived initial pruning. The graph contains nodes for
+               features, errors, tokens, and logits, along with their connections.
+        node_ids: List of node_id strings for feature nodes to include in the subgraph.
+                 Format: "layer_featidx_pos" (e.g., "5_123_10" for layer 5, feature 123,
+                 position 10). Features not in this list are treated as pruned/errors.
+
+    Returns:
+        tuple[float, float]: A tuple containing:
+            - replacement_score: Fraction of token-to-logit influence through subgraph
+                               features (0-1)
+            - completeness_score: Weighted fraction of non-error inputs across all nodes
+                                 in the subgraph (0-1)
+    """
+    n_logits = len(graph.logit_tokens)
+    n_tokens = len(graph.input_tokens)
+    n_features = len(graph.selected_features)  # Only features in the pruned graph
+    n_layers = graph.cfg.n_layers
+
+    # Convert node_ids to a subgraph feature mask
+    subgraph_feature_mask = torch.zeros(n_features, dtype=torch.bool)
+    
+    # Parse node_ids to extract (layer, pos, feat_idx)
+    target_features = set()
+    for node_id in node_ids:
+        parts = node_id.split('_')
+        # Feature nodes have format "layer_featidx_pos"
+        # Skip non-feature nodes (token: "E_vocab_pos", logit: where layer > n_layers)
+        if len(parts) == 3 and not node_id.startswith('E_'):
+            layer, feat_idx, pos = int(parts[0]), int(parts[1]), int(parts[2])
+            # Only consider if it's a valid layer (not a logit node)
+            if layer < n_layers:
+                target_features.add((layer, pos, feat_idx))
+    
+    # Find matching indices in selected_features
+    for i in range(n_features):
+        active_idx = graph.selected_features[i].item()
+        layer, pos, feat_idx = graph.active_features[active_idx].tolist()
+        
+        if (layer, pos, feat_idx) in target_features:
+            subgraph_feature_mask[i] = True
+
+    # In the pruned graph's adjacency matrix:
+    # - First n_features rows/cols are the surviving feature nodes
+    # - Next n_tokens * n_layers rows/cols are error nodes (one per layer per token)
+    # - Next n_tokens rows/cols are token embedding nodes
+    # - Last n_logits rows/cols are logit nodes
+    error_start = n_features
+    error_end = error_start + n_tokens * n_layers
+    token_end = error_end + n_tokens
+
+    # Create modified adjacency matrix
+    modified_adjacency = graph.adjacency_matrix.clone()
+
+    # For each pruned feature, merge its edges with the corresponding error node
+    for feature_idx in range(n_features):
+        if subgraph_feature_mask[feature_idx].item():
+            # Feature is pinned (included in subgraph)
+            pass
+        else:
+            # Feature is pruned (not included in subgraph)
+            # Get the layer and position of this feature from active_features
+            # graph.selected_features[feature_idx] is an index into active_features
+            layer, pos, _ = graph.active_features[graph.selected_features[feature_idx]]
+
+            # Calculate the corresponding error node index
+            # Error nodes are organized as: error[layer][position]
+            # Index = error_start + layer * n_tokens + pos
+            error_node_idx = error_start + int(layer.item()) * n_tokens + int(pos.item())
+
+            # Add this feature's outgoing edges to the error node's outgoing edges
+            modified_adjacency[:, error_node_idx] += modified_adjacency[:, feature_idx]
+
+            # Zero out the pruned feature's edges (both incoming and outgoing)
+            modified_adjacency[feature_idx, :] = 0
+            modified_adjacency[:, feature_idx] = 0
+
+    # Compute scores using the modified adjacency matrix
+    logit_weights = torch.zeros(
+        modified_adjacency.shape[0], device=modified_adjacency.device
+    )
+    logit_weights[-n_logits:] = graph.logit_probabilities
+
+    normalized_matrix = normalize_matrix(modified_adjacency)
+    node_influence = compute_influence(normalized_matrix, logit_weights)
+    
+    token_influence = node_influence[error_end:token_end].sum()
+    error_influence = node_influence[error_start:error_end].sum()
+    replacement_score = token_influence / (token_influence + error_influence)
+    non_error_fractions = 1 - normalized_matrix[:, error_start:error_end].sum(dim=-1)
+    
+    output_influence = node_influence + logit_weights    
+    completeness_score = (non_error_fractions * output_influence).sum() / output_influence.sum()
+
+    return replacement_score.item(), completeness_score.item()

--- a/circuit_tracer/utils/create_graph_files.py
+++ b/circuit_tracer/utils/create_graph_files.py
@@ -191,7 +191,6 @@ def create_graph_files(
     scan=None,
     node_threshold=0.8,
     edge_threshold=0.98,
-    save_pruned_graph_pt=False,
 ):
     total_start_time = time.time()
 
@@ -224,12 +223,6 @@ def create_graph_files(
     nodes = create_nodes(graph, node_mask, tokenizer, cumulative_scores)
     used_nodes, used_edges = create_used_nodes_and_edges(graph, nodes, edge_mask)
     model = build_model(graph, used_nodes, used_edges, slug, scan, node_threshold, tokenizer)
-
-    if save_pruned_graph_pt:
-        pruned_graph = create_pruned_graph(graph, node_mask, edge_mask)
-        pruned_graph_path = os.path.join(output_path, f"{slug}_pruned.pt")
-        pruned_graph.to_pt(pruned_graph_path)
-        logger.info(f"Pruned graph saved to {pruned_graph_path}")
 
     # Write the output locally
     with open(os.path.join(output_path, f"{slug}.json"), "w") as f:

--- a/circuit_tracer/utils/create_graph_files.py
+++ b/circuit_tracer/utils/create_graph_files.py
@@ -143,6 +143,46 @@ def build_model(graph: Graph, used_nodes, used_edges, slug, scan, node_threshold
 
     return full_model
 
+def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor) -> Graph:
+    """Create a pruned version of the graph by applying node and edge masks.
+    
+    Args:
+        graph: The original graph
+        node_mask: Boolean tensor indicating which nodes to keep
+        edge_mask: Boolean tensor indicating which edges to keep
+    
+    Returns:
+        A new Graph object containing only the pruned nodes and edges
+    
+    Note:
+        The pruned graph maintains the same structure as the original graph
+        (same dimensions for adjacency matrix, selected_features, etc.) but
+        with removed nodes/edges represented as zeros in the adjacency matrix.
+        This ensures that functions like compute_graph_scores can correctly
+        interpret the graph structure.
+    """
+    # Apply masks to adjacency matrix - this is the ONLY change we make
+    # All removed nodes/edges are represented as zeros
+    pruned_adjacency = graph.adjacency_matrix.clone()
+    pruned_adjacency[~node_mask] = 0
+    pruned_adjacency[:, ~node_mask] = 0
+    pruned_adjacency = pruned_adjacency * edge_mask
+    
+    # Keep all other fields unchanged to preserve the graph structure
+    # The pruning is represented entirely by the zeros in the adjacency matrix
+    return Graph(
+        input_string=graph.input_string,
+        input_tokens=graph.input_tokens,
+        active_features=graph.active_features,
+        adjacency_matrix=pruned_adjacency,
+        cfg=graph.cfg,
+        logit_tokens=graph.logit_tokens,
+        logit_probabilities=graph.logit_probabilities,
+        selected_features=graph.selected_features,
+        activation_values=graph.activation_values,
+        scan=graph.scan,
+    )
+
 
 def create_graph_files(
     graph_or_path: Graph | str,
@@ -151,6 +191,7 @@ def create_graph_files(
     scan=None,
     node_threshold=0.8,
     edge_threshold=0.98,
+    save_pruned_graph_pt=False,
 ):
     total_start_time = time.time()
 
@@ -183,6 +224,12 @@ def create_graph_files(
     nodes = create_nodes(graph, node_mask, tokenizer, cumulative_scores)
     used_nodes, used_edges = create_used_nodes_and_edges(graph, nodes, edge_mask)
     model = build_model(graph, used_nodes, used_edges, slug, scan, node_threshold, tokenizer)
+
+    if save_pruned_graph_pt:
+        pruned_graph = create_pruned_graph(graph, node_mask, edge_mask)
+        pruned_graph_path = os.path.join(output_path, f"{slug}_pruned.pt")
+        pruned_graph.to_pt(pruned_graph_path)
+        logger.info(f"Pruned graph saved to {pruned_graph_path}")
 
     # Write the output locally
     with open(os.path.join(output_path, f"{slug}.json"), "w") as f:

--- a/circuit_tracer/utils/create_graph_files.py
+++ b/circuit_tracer/utils/create_graph_files.py
@@ -143,17 +143,18 @@ def build_model(graph: Graph, used_nodes, used_edges, slug, scan, node_threshold
 
     return full_model
 
+
 def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor) -> Graph:
     """Create a pruned version of the graph by applying node and edge masks.
-    
+
     Args:
         graph: The original graph
         node_mask: Boolean tensor indicating which nodes to keep
         edge_mask: Boolean tensor indicating which edges to keep
-    
+
     Returns:
         A new Graph object containing only the pruned nodes and edges
-    
+
     Note:
         The pruned graph maintains the same structure as the original graph
         (same dimensions for adjacency matrix, selected_features, etc.) but
@@ -167,7 +168,7 @@ def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.
     pruned_adjacency[~node_mask] = 0
     pruned_adjacency[:, ~node_mask] = 0
     pruned_adjacency = pruned_adjacency * edge_mask
-    
+
     # Keep all other fields unchanged to preserve the graph structure
     # The pruning is represented entirely by the zeros in the adjacency matrix
     return Graph(

--- a/circuit_tracer/utils/create_graph_files.py
+++ b/circuit_tracer/utils/create_graph_files.py
@@ -144,47 +144,6 @@ def build_model(graph: Graph, used_nodes, used_edges, slug, scan, node_threshold
     return full_model
 
 
-def create_pruned_graph(graph: Graph, node_mask: torch.Tensor, edge_mask: torch.Tensor) -> Graph:
-    """Create a pruned version of the graph by applying node and edge masks.
-
-    Args:
-        graph: The original graph
-        node_mask: Boolean tensor indicating which nodes to keep
-        edge_mask: Boolean tensor indicating which edges to keep
-
-    Returns:
-        A new Graph object containing only the pruned nodes and edges
-
-    Note:
-        The pruned graph maintains the same structure as the original graph
-        (same dimensions for adjacency matrix, selected_features, etc.) but
-        with removed nodes/edges represented as zeros in the adjacency matrix.
-        This ensures that functions like compute_graph_scores can correctly
-        interpret the graph structure.
-    """
-    # Apply masks to adjacency matrix - this is the ONLY change we make
-    # All removed nodes/edges are represented as zeros
-    pruned_adjacency = graph.adjacency_matrix.clone()
-    pruned_adjacency[~node_mask] = 0
-    pruned_adjacency[:, ~node_mask] = 0
-    pruned_adjacency = pruned_adjacency * edge_mask
-
-    # Keep all other fields unchanged to preserve the graph structure
-    # The pruning is represented entirely by the zeros in the adjacency matrix
-    return Graph(
-        input_string=graph.input_string,
-        input_tokens=graph.input_tokens,
-        active_features=graph.active_features,
-        adjacency_matrix=pruned_adjacency,
-        cfg=graph.cfg,
-        logit_tokens=graph.logit_tokens,
-        logit_probabilities=graph.logit_probabilities,
-        selected_features=graph.selected_features,
-        activation_values=graph.activation_values,
-        scan=graph.scan,
-    )
-
-
 def create_graph_files(
     graph_or_path: Graph | str,
     slug: str,

--- a/demos/replacement_completeness_scores.ipynb
+++ b/demos/replacement_completeness_scores.ipynb
@@ -190,7 +190,7 @@
     "We pass in the original graph, instead of the pruned graph node, so that we can the full context.\n",
     "However, if you only have the pruned graph, you can just use that as well for an approximation, assuming that the pruned edges/nodes were not very important.\n",
     "\n",
-    "Since we've generated this graph before, we know what `node_id`s we want to pin to the subgraph. Pass this to `compute_subgraph_scores`, along with the original graph and the masks."
+    "Since we've generated this graph before, we know what `node_id`s we want to pin to the subgraph. Pass this to `compute_subgraph_scores`, along with the original graph."
    ]
   },
   {
@@ -222,10 +222,10 @@
     "\n",
     "pinned_features = torch.tensor(pinned_features, dtype=dtype)\n",
     "\n",
-    "(subgraph_replacement_score, subgraph_completeness_score) = compute_subgraph_scores(graph, pinned_features, node_mask, edge_mask)\n",
+    "(subgraph_replacement_score, subgraph_completeness_score) = compute_subgraph_scores(graph, pinned_features)\n",
     "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")\n",
     "\n",
-    "(pruned_subgraph_replacement_score, pruned_subgraph_completeness_score) = compute_subgraph_scores(pruned_graph, pinned_features, node_mask, edge_mask)\n",
+    "(pruned_subgraph_replacement_score, pruned_subgraph_completeness_score) = compute_subgraph_scores(pruned_graph, pinned_features)\n",
     "print(f\"Pruned subgraph: replacement_score={pruned_subgraph_replacement_score}, completeness_score={pruned_subgraph_completeness_score}\")"
    ]
   },

--- a/demos/replacement_completeness_scores.ipynb
+++ b/demos/replacement_completeness_scores.ipynb
@@ -49,7 +49,7 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "from circuit_tracer.graph import Graph, compute_graph_scores, compute_subgraph_scores\n",
+    "from circuit_tracer.graph import compute_graph_scores, compute_subgraph_scores\n",
     "from circuit_tracer.utils.create_graph_files import create_pruned_graph, prune_graph\n",
     "from circuit_tracer import ReplacementModel, attribute\n",
     "from circuit_tracer.utils.hf_utils import load_transcoder_from_hub"
@@ -165,7 +165,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's get the replacement and completeness scores for the pruned graph. It should be lower, since we pruned nodes and edges."
+    "Now, let's get the replacement and completeness scores for the pruned graph - how well does this pruned graph explain the model's output? It should be lower, since we pruned nodes and edges.\n",
+    "Remember that we zeroed out the pruned nodes/edges, so we aren't merging the weights into the error nodes."
    ]
   },
   {
@@ -184,7 +185,11 @@
     "id": "VXfD-5GrmS8l"
    },
    "source": [
-    "Finally, we want to get the subgraph scores. A subgraph is made up of pinned nodes. Since we've generated this graph before, we know what `node_id`s we want to pin to the subgraph. Pass this to `compute_subgraph_scores`, along with the pruned graph. This score should be even lower."
+    "Finally, we want to get the subgraph scores. Importantly, this is different than getting the pruned scores above, because here, we explicitly merge the non-subgraph features into error nodes.\n",
+    "We pass in the original graph, instead of the pruned graph node, so that we can the full context.\n",
+    "However, if you only have the pruned graph, you can just use that as well for an approximation, assuming that the pruned edges/nodes were not very important.\n",
+    "\n",
+    "Since we've generated this graph before, we know what `node_id`s we want to pin to the subgraph. Pass this to `compute_subgraph_scores`, along with the original graph and the masks."
    ]
   },
   {
@@ -197,8 +202,11 @@
    "source": [
     "subgraph_node_ids = ['27_22605_10','20_15589_10','E_26865_9','21_5943_10','23_12237_10','20_15589_9','16_25_9','14_2268_9','18_8959_10','4_13154_9','7_6861_9','19_1445_10','E_2329_7','E_6037_4','0_13727_7','6_4012_7','17_7178_10','15_4494_4','6_4662_4','4_7671_4','3_13984_4','1_1000_4','19_7477_9','18_6101_10','16_4298_10','7_691_10']\n",
     "\n",
-    "(subgraph_replacement_score, subgraph_completeness_score) = compute_subgraph_scores(pruned_graph, subgraph_node_ids)\n",
-    "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")"
+    "(subgraph_replacement_score, subgraph_completeness_score) = compute_subgraph_scores(graph, subgraph_node_ids, node_mask, edge_mask)\n",
+    "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")\n",
+    "\n",
+    "(pruned_subgraph_replacement_score, pruned_subgraph_completeness_score) = compute_subgraph_scores(pruned_graph, subgraph_node_ids, node_mask, edge_mask)\n",
+    "print(f\"Pruned subgraph: replacement_score={pruned_subgraph_replacement_score}, completeness_score={pruned_subgraph_completeness_score}\")"
    ]
   },
   {
@@ -220,7 +228,8 @@
    "source": [
     "print(f\"Unpruned graph: replacement_score={unpruned_replacement_score}, completeness_score={unpruned_completeness_score}\")\n",
     "print(f\"Pruned graph: replacement_score={pruned_replacement_score}, completeness_score={pruned_completeness_score}\")\n",
-    "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")"
+    "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")\n",
+    "print(f\"Pruned subgraph: replacement_score={pruned_subgraph_replacement_score}, completeness_score={pruned_subgraph_completeness_score}\")"
    ]
   }
  ],

--- a/demos/replacement_completeness_scores.ipynb
+++ b/demos/replacement_completeness_scores.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Qa5r1-7RmS8j"
+   },
+   "source": [
+    "# Replacement and Completeness Scores for Graph, Pruned Graph, and Subgraph \n",
+    "\n",
+    "<!-- <a target=\"_blank\" href=\"https://colab.research.google.com/github/safety-research/circuit-tracer/blob/main/demos/replacement_completeness_scores.ipynb\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a> -->\n",
+    "\n",
+    "In this demo, you'll generate a graph and calculate the replacement and completeness scores for both the graph and subgraph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#@title Colab Setup Environment\n",
+    "\n",
+    "try:\n",
+    "    import google.colab\n",
+    "    !mkdir -p repository && cd repository && \\\n",
+    "     git clone https://github.com/safety-research/circuit-tracer && \\\n",
+    "     curl -LsSf https://astral.sh/uv/install.sh | sh && \\\n",
+    "     uv pip install -e circuit-tracer/\n",
+    "\n",
+    "    import sys\n",
+    "    from huggingface_hub import notebook_login\n",
+    "    sys.path.append('repository/circuit-tracer')\n",
+    "    sys.path.append('repository/circuit-tracer/demos')\n",
+    "    notebook_login(new_session=False)\n",
+    "    IN_COLAB = True\n",
+    "except ImportError:\n",
+    "    IN_COLAB = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "P8fNhpqzmS8k"
+   },
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from circuit_tracer.graph import Graph, compute_graph_scores, compute_subgraph_scores\n",
+    "from circuit_tracer.utils.create_graph_files import create_pruned_graph, prune_graph\n",
+    "from circuit_tracer import ReplacementModel, attribute\n",
+    "from circuit_tracer.utils.hf_utils import load_transcoder_from_hub"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ZN_3kEyfmS8k"
+   },
+   "source": [
+    "Let's first load the model and transcoders for `gemma-2-2b`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transcoder_set = \"gemma\"\n",
+    "model = \"gemma-2-2b\"\n",
+    "dtype = torch.bfloat16\n",
+    "\n",
+    "transcoder, config = load_transcoder_from_hub(\n",
+    "    transcoder_set,\n",
+    "    dtype=dtype,\n",
+    "    lazy_encoder=False,\n",
+    "    lazy_decoder=True,\n",
+    ")\n",
+    "\n",
+    "model_instance = ReplacementModel.from_pretrained_and_transcoders(\n",
+    "    model, transcoder, dtype=dtype\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we perform the attribution to generate the graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "BBsETpl0mS8l"
+   },
+   "outputs": [],
+   "source": [
+    "prompt = \"Fact: The capital of the state containing Dallas is\"\n",
+    "max_n_logits = 10\n",
+    "desired_logit_prob = 0.95\n",
+    "max_feature_nodes = 5000\n",
+    "batch_size = 256\n",
+    "\n",
+    "graph = attribute(\n",
+    "    prompt=prompt,\n",
+    "    model=model_instance,\n",
+    "    max_n_logits=max_n_logits,\n",
+    "    desired_logit_prob=desired_logit_prob,\n",
+    "    batch_size=batch_size,\n",
+    "    verbose=True,\n",
+    "    max_feature_nodes=max_feature_nodes,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's get the replacement and completeness scores for this whole graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(unpruned_replacement_score, unpruned_completeness_score) = compute_graph_scores(graph)\n",
+    "print(f\"Unpruned graph: replacement_score={unpruned_replacement_score}, completeness_score={unpruned_completeness_score}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dcZNR0egmS8l"
+   },
+   "source": [
+    "Next, we prune this graph. The `prune_graph` gives us the node and edge masks, but we need a Graph, so we call `create_pruned_graph`, which will give us a Graph of the same dimensions, with the pruned nodes/edges zeroed out. We keep it the same dimensions so that we can refer to the same nodes/edges in the same indexes when using it later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "5XBwNyq4mS8l"
+   },
+   "outputs": [],
+   "source": [
+    "node_threshold = 0.7\n",
+    "edge_threshold = 0.9\n",
+    "\n",
+    "node_mask, edge_mask, _ = (\n",
+    "    el.cpu() for el in prune_graph(graph, node_threshold, edge_threshold)\n",
+    ")\n",
+    "pruned_graph = create_pruned_graph(graph, node_mask, edge_mask)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's get the replacement and completeness scores for the pruned graph. It should be lower, since we pruned nodes and edges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(pruned_replacement_score, pruned_completeness_score) = compute_graph_scores(pruned_graph)\n",
+    "print(f\"Pruned graph: replacement_score={pruned_replacement_score}, completeness_score={pruned_completeness_score}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VXfD-5GrmS8l"
+   },
+   "source": [
+    "Finally, we want to get the subgraph scores. A subgraph is made up of pinned nodes. Since we've generated this graph before, we know what `node_id`s we want to pin to the subgraph. Pass this to `compute_subgraph_scores`, along with the pruned graph. This score should be even lower."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wx2XiXVjmS8l"
+   },
+   "outputs": [],
+   "source": [
+    "subgraph_node_ids = ['27_22605_10','20_15589_10','E_26865_9','21_5943_10','23_12237_10','20_15589_9','16_25_9','14_2268_9','18_8959_10','4_13154_9','7_6861_9','19_1445_10','E_2329_7','E_6037_4','0_13727_7','6_4012_7','17_7178_10','15_4494_4','6_4662_4','4_7671_4','3_13984_4','1_1000_4','19_7477_9','18_6101_10','16_4298_10','7_691_10']\n",
+    "\n",
+    "(subgraph_replacement_score, subgraph_completeness_score) = compute_subgraph_scores(pruned_graph, subgraph_node_ids)\n",
+    "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "RUn1YKnUmS8l"
+   },
+   "source": [
+    "Okay, let's finally print out all 3 scores so we can compare them easily."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "uCo4FSQwqcBl"
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"Unpruned graph: replacement_score={unpruned_replacement_score}, completeness_score={unpruned_completeness_score}\")\n",
+    "print(f\"Pruned graph: replacement_score={pruned_replacement_score}, completeness_score={pruned_completeness_score}\")\n",
+    "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/demos/replacement_completeness_scores.ipynb
+++ b/demos/replacement_completeness_scores.ipynb
@@ -52,7 +52,8 @@
     "from circuit_tracer.graph import compute_graph_scores, compute_subgraph_scores\n",
     "from circuit_tracer.utils.create_graph_files import create_pruned_graph, prune_graph\n",
     "from circuit_tracer import ReplacementModel, attribute\n",
-    "from circuit_tracer.utils.hf_utils import load_transcoder_from_hub"
+    "from circuit_tracer.utils.hf_utils import load_transcoder_from_hub\n",
+    "from circuit_tracer.utils.decode_url_features import Feature"
    ]
   },
   {
@@ -200,12 +201,31 @@
    },
    "outputs": [],
    "source": [
+    "# we know what pinned node IDs we want to include in the subgraph\n",
     "subgraph_node_ids = ['27_22605_10','20_15589_10','E_26865_9','21_5943_10','23_12237_10','20_15589_9','16_25_9','14_2268_9','18_8959_10','4_13154_9','7_6861_9','19_1445_10','E_2329_7','E_6037_4','0_13727_7','6_4012_7','17_7178_10','15_4494_4','6_4662_4','4_7671_4','3_13984_4','1_1000_4','19_7477_9','18_6101_10','16_4298_10','7_691_10']\n",
     "\n",
-    "(subgraph_replacement_score, subgraph_completeness_score) = compute_subgraph_scores(graph, subgraph_node_ids, node_mask, edge_mask)\n",
+    "# convert these to Feature type array\n",
+    "pinned_features = []\n",
+    "for node_id in subgraph_node_ids:\n",
+    "    parts = node_id.split('_')\n",
+    "    layer = parts[0]\n",
+    "    # Don't include embed\n",
+    "    if layer == 'E':\n",
+    "        continue\n",
+    "    layer = int(layer)\n",
+    "    # Don't include logit nodes\n",
+    "    if layer > graph.cfg.n_layers:\n",
+    "        continue\n",
+    "    feature_idx = int(parts[1])\n",
+    "    pos = int(parts[2])\n",
+    "    pinned_features.append(Feature(layer=layer, pos=pos, feature_idx=feature_idx))\n",
+    "\n",
+    "pinned_features = torch.tensor(pinned_features, dtype=dtype)\n",
+    "\n",
+    "(subgraph_replacement_score, subgraph_completeness_score) = compute_subgraph_scores(graph, pinned_features, node_mask, edge_mask)\n",
     "print(f\"Subgraph: replacement_score={subgraph_replacement_score}, completeness_score={subgraph_completeness_score}\")\n",
     "\n",
-    "(pruned_subgraph_replacement_score, pruned_subgraph_completeness_score) = compute_subgraph_scores(pruned_graph, subgraph_node_ids, node_mask, edge_mask)\n",
+    "(pruned_subgraph_replacement_score, pruned_subgraph_completeness_score) = compute_subgraph_scores(pruned_graph, pinned_features, node_mask, edge_mask)\n",
     "print(f\"Pruned subgraph: replacement_score={pruned_subgraph_replacement_score}, completeness_score={pruned_subgraph_completeness_score}\")"
    ]
   },

--- a/demos/replacement_completeness_scores.ipynb
+++ b/demos/replacement_completeness_scores.ipynb
@@ -52,8 +52,7 @@
     "from circuit_tracer.graph import compute_graph_scores, compute_subgraph_scores, create_pruned_graph\n",
     "from circuit_tracer.utils.create_graph_files import prune_graph\n",
     "from circuit_tracer import ReplacementModel, attribute\n",
-    "from circuit_tracer.utils.hf_utils import load_transcoder_from_hub\n",
-    "from circuit_tracer.utils.decode_url_features import Feature"
+    "from circuit_tracer.utils.hf_utils import load_transcoder_from_hub"
    ]
   },
   {
@@ -204,7 +203,7 @@
     "# we know what pinned node IDs we want to include in the subgraph\n",
     "subgraph_node_ids = ['27_22605_10','20_15589_10','E_26865_9','21_5943_10','23_12237_10','20_15589_9','16_25_9','14_2268_9','18_8959_10','4_13154_9','7_6861_9','19_1445_10','E_2329_7','E_6037_4','0_13727_7','6_4012_7','17_7178_10','15_4494_4','6_4662_4','4_7671_4','3_13984_4','1_1000_4','19_7477_9','18_6101_10','16_4298_10','7_691_10']\n",
     "\n",
-    "# convert these to Feature type array\n",
+    "# convert these to (layer, pos, feature_idx) tuple array\n",
     "pinned_features = []\n",
     "for node_id in subgraph_node_ids:\n",
     "    parts = node_id.split('_')\n",
@@ -218,7 +217,7 @@
     "        continue\n",
     "    feature_idx = int(parts[1])\n",
     "    pos = int(parts[2])\n",
-    "    pinned_features.append(Feature(layer=layer, pos=pos, feature_idx=feature_idx))\n",
+    "    pinned_features.append((layer, pos, feature_idx))\n",
     "\n",
     "pinned_features = torch.tensor(pinned_features, dtype=dtype)\n",
     "\n",

--- a/demos/replacement_completeness_scores.ipynb
+++ b/demos/replacement_completeness_scores.ipynb
@@ -49,8 +49,8 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "from circuit_tracer.graph import compute_graph_scores, compute_subgraph_scores\n",
-    "from circuit_tracer.utils.create_graph_files import create_pruned_graph, prune_graph\n",
+    "from circuit_tracer.graph import compute_graph_scores, compute_subgraph_scores, create_pruned_graph\n",
+    "from circuit_tracer.utils.create_graph_files import prune_graph\n",
     "from circuit_tracer import ReplacementModel, attribute\n",
     "from circuit_tracer.utils.hf_utils import load_transcoder_from_hub\n",
     "from circuit_tracer.utils.decode_url_features import Feature"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -286,14 +286,10 @@ def test_compute_subgraph_scores():
     )
 
     # Scores should be lower when excluding Feature 1
-    assert (
-        replacement_partial <= replacement_all
-    ), "Partial subgraph should have lower or equal replacement score"
+    assert replacement_partial <= replacement_all, (
+        "Partial subgraph should have lower or equal replacement score"
+    )
 
     # Scores should still be in valid range
-    assert (
-        0 <= replacement_partial <= 1
-    ), f"Replacement score {replacement_partial} out of range"
-    assert (
-        0 <= completeness_partial <= 1
-    ), f"Completeness score {completeness_partial} out of range"
+    assert 0 <= replacement_partial <= 1, f"Replacement score {replacement_partial} out of range"
+    assert 0 <= completeness_partial <= 1, f"Completeness score {completeness_partial} out of range"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -202,11 +202,13 @@ def test_compute_graph_scores():
     # With mostly feature paths and few error paths, scores should be high
     expected_replacement = 0.9166666865348816
     expected_completeness = 0.9696969985961914
-    
-    assert abs(replacement_score - expected_replacement) / expected_replacement < 0.1, \
+
+    assert abs(replacement_score - expected_replacement) / expected_replacement < 0.1, (
         f"Replacement score {replacement_score} not within 10% of {expected_replacement}"
-    assert abs(completeness_score - expected_completeness) / expected_completeness < 0.1, \
+    )
+    assert abs(completeness_score - expected_completeness) / expected_completeness < 0.1, (
         f"Completeness score {completeness_score} not within 10% of {expected_completeness}"
+    )
 
     # Scores should be between 0 and 1
     assert 0 <= replacement_score <= 1, f"Replacement score {replacement_score} out of range"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,7 +2,13 @@ import numpy as np
 import torch
 from transformer_lens import HookedTransformerConfig
 
-from circuit_tracer.graph import Graph, compute_edge_influence, compute_node_influence
+from circuit_tracer.graph import (
+    Graph,
+    compute_edge_influence,
+    compute_graph_scores,
+    compute_node_influence,
+    compute_subgraph_scores,
+)
 from circuit_tracer.utils import get_default_device
 
 
@@ -131,3 +137,163 @@ def test_small_graph():
 
     edge_influence_on_logits = compute_edge_influence(pruned_adjacency_matrix, logit_weights)
     assert torch.allclose(edge_influence_on_logits, post_pruning_edge_matrix)
+
+
+def test_compute_graph_scores():
+    """Test compute_graph_scores with a small test graph."""
+    # Create a small graph with:
+    # - 2 features (nodes 0-1)
+    # - 4 error nodes: 2 layers * 2 tokens (nodes 2-5)
+    # - 2 token nodes (nodes 6-7)
+    # - 1 logit node (node 8)
+
+    # Build adjacency matrix (9x9)
+    # Token -> Feature -> Logit path (high replacement score)
+    adjacency_matrix = torch.zeros([9, 9])
+
+    # Token 0 (node 6) -> Feature 0 (node 0): 0.8
+    adjacency_matrix[0, 6] = 0.8
+    # Token 1 (node 7) -> Feature 1 (node 1): 0.8
+    adjacency_matrix[1, 7] = 0.8
+
+    # Feature 0 (node 0) -> Logit (node 8): 0.5
+    adjacency_matrix[8, 0] = 0.5
+    # Feature 1 (node 1) -> Logit (node 8): 0.5
+    adjacency_matrix[8, 1] = 0.5
+
+    # Token 0 (node 6) -> Error (node 2): 0.2
+    adjacency_matrix[2, 6] = 0.2
+    # Token 1 (node 7) -> Error (node 3): 0.2
+    adjacency_matrix[3, 7] = 0.2
+
+    # Error (node 2) -> Logit (node 8): 0.1
+    adjacency_matrix[8, 2] = 0.1
+
+    # Dummy model config
+    cfg_dict = {
+        "n_layers": 2,
+        "d_model": 8,
+        "n_ctx": 8192,
+        "d_head": 4,
+        "model_name": "test-model",
+        "n_heads": 2,
+        "d_mlp": 16,
+        "act_fn": "gelu",
+        "d_vocab": 16,
+    }
+    cfg = HookedTransformerConfig.from_dict(cfg_dict)
+
+    # Create graph
+    test_graph = Graph(
+        input_string="ab",
+        input_tokens=torch.tensor([0, 1]),
+        active_features=torch.tensor([[0, 0, 100], [1, 1, 200]]),
+        adjacency_matrix=adjacency_matrix,
+        cfg=cfg,
+        logit_tokens=torch.tensor([5]),
+        logit_probabilities=torch.tensor([1.0]),
+        selected_features=torch.tensor([0, 1]),
+        activation_values=torch.tensor([1.0, 2.0]),
+    )
+
+    # Compute scores
+    replacement_score, completeness_score = compute_graph_scores(test_graph)
+
+    # With mostly feature paths and few error paths, scores should be high
+    assert replacement_score > 0.5, f"Expected high replacement score, got {replacement_score}"
+    assert completeness_score > 0.5, f"Expected high completeness score, got {completeness_score}"
+
+    # Scores should be between 0 and 1
+    assert 0 <= replacement_score <= 1, f"Replacement score {replacement_score} out of range"
+    assert 0 <= completeness_score <= 1, f"Completeness score {completeness_score} out of range"
+
+
+def test_compute_subgraph_scores():
+    """Test compute_subgraph_scores with a small test graph."""
+    # Create a small graph with:
+    # - 3 features (nodes 0-2)
+    # - 4 error nodes: 2 layers * 2 tokens (nodes 3-6)
+    # - 2 token nodes (nodes 7-8)
+    # - 1 logit node (node 9)
+
+    # Build adjacency matrix (10x10)
+    adjacency_matrix = torch.zeros([10, 10])
+
+    # Token 0 (node 7) -> Feature 0 (node 0): 0.5
+    adjacency_matrix[0, 7] = 0.5
+    # Token 0 (node 7) -> Feature 1 (node 1): 0.3
+    adjacency_matrix[1, 7] = 0.3
+    # Token 1 (node 8) -> Feature 2 (node 2): 0.6
+    adjacency_matrix[2, 8] = 0.6
+
+    # Feature 0 (node 0) -> Logit (node 9): 0.4
+    adjacency_matrix[9, 0] = 0.4
+    # Feature 1 (node 1) -> Logit (node 9): 0.3
+    adjacency_matrix[9, 1] = 0.3
+    # Feature 2 (node 2) -> Logit (node 9): 0.5
+    adjacency_matrix[9, 2] = 0.5
+
+    # Token 0 -> Error (node 3): 0.2
+    adjacency_matrix[3, 7] = 0.2
+    # Error (node 3) -> Logit: 0.1
+    adjacency_matrix[9, 3] = 0.1
+
+    # Dummy model config
+    cfg_dict = {
+        "n_layers": 2,
+        "d_model": 8,
+        "n_ctx": 8192,
+        "d_head": 4,
+        "model_name": "test-model",
+        "n_heads": 2,
+        "d_mlp": 16,
+        "act_fn": "gelu",
+        "d_vocab": 16,
+    }
+    cfg = HookedTransformerConfig.from_dict(cfg_dict)
+
+    # Create graph
+    # Features: (layer, pos, feature_idx)
+    # Feature 0: layer 0, pos 0, feature 100
+    # Feature 1: layer 0, pos 0, feature 200
+    # Feature 2: layer 1, pos 1, feature 300
+    test_graph = Graph(
+        input_string="ab",
+        input_tokens=torch.tensor([0, 1]),
+        active_features=torch.tensor([[0, 0, 100], [0, 0, 200], [1, 1, 300]]),
+        adjacency_matrix=adjacency_matrix,
+        cfg=cfg,
+        logit_tokens=torch.tensor([5]),
+        logit_probabilities=torch.tensor([1.0]),
+        selected_features=torch.tensor([0, 1, 2]),
+        activation_values=torch.tensor([1.0, 2.0, 3.0]),
+    )
+
+    # Test 1: Include all features in subgraph
+    all_features = [(0, 0, 100), (0, 0, 200), (1, 1, 300)]
+    replacement_all, completeness_all = compute_subgraph_scores(test_graph, all_features)
+
+    # With all features, scores should match compute_graph_scores
+    graph_replacement, graph_completeness = compute_graph_scores(test_graph)
+    assert torch.isclose(
+        torch.tensor(replacement_all), torch.tensor(graph_replacement), atol=1e-5
+    ), "Subgraph with all features should match full graph"
+
+    # Test 2: Include only Feature 0 and 2 (exclude Feature 1)
+    partial_features = [(0, 0, 100), (1, 1, 300)]
+    replacement_partial, completeness_partial = compute_subgraph_scores(
+        test_graph, partial_features
+    )
+
+    # Scores should be lower when excluding Feature 1
+    assert (
+        replacement_partial <= replacement_all
+    ), "Partial subgraph should have lower or equal replacement score"
+
+    # Scores should still be in valid range
+    assert (
+        0 <= replacement_partial <= 1
+    ), f"Replacement score {replacement_partial} out of range"
+    assert (
+        0 <= completeness_partial <= 1
+    ), f"Completeness score {completeness_partial} out of range"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -200,8 +200,13 @@ def test_compute_graph_scores():
     replacement_score, completeness_score = compute_graph_scores(test_graph)
 
     # With mostly feature paths and few error paths, scores should be high
-    assert replacement_score > 0.5, f"Expected high replacement score, got {replacement_score}"
-    assert completeness_score > 0.5, f"Expected high completeness score, got {completeness_score}"
+    expected_replacement = 0.9166666865348816
+    expected_completeness = 0.9696969985961914
+    
+    assert abs(replacement_score - expected_replacement) / expected_replacement < 0.1, \
+        f"Replacement score {replacement_score} not within 10% of {expected_replacement}"
+    assert abs(completeness_score - expected_completeness) / expected_completeness < 0.1, \
+        f"Completeness score {completeness_score} not within 10% of {expected_completeness}"
 
     # Scores should be between 0 and 1
     assert 0 <= replacement_score <= 1, f"Replacement score {replacement_score} out of range"
@@ -284,7 +289,6 @@ def test_compute_subgraph_scores():
     replacement_partial, completeness_partial = compute_subgraph_scores(
         test_graph, partial_features
     )
-
     # Scores should be lower when excluding Feature 1
     assert replacement_partial <= replacement_all, (
         "Partial subgraph should have lower or equal replacement score"
@@ -293,3 +297,13 @@ def test_compute_subgraph_scores():
     # Scores should still be in valid range
     assert 0 <= replacement_partial <= 1, f"Replacement score {replacement_partial} out of range"
     assert 0 <= completeness_partial <= 1, f"Completeness score {completeness_partial} out of range"
+
+    # Verify scores are within 10% of expected values
+    expected_replacement = 0.7647058963775635
+    expected_completeness = 0.8974359631538391
+    assert abs(replacement_partial - expected_replacement) / expected_replacement <= 0.1, (
+        f"Replacement score {replacement_partial} not within 10% of {expected_replacement}"
+    )
+    assert abs(completeness_partial - expected_completeness) / expected_completeness <= 0.1, (
+        f"Completeness score {completeness_partial} not within 10% of {expected_completeness}"
+    )


### PR DESCRIPTION
This PR adds subgraph replacement and completeness score calculation, which treats pruned features as errors. It merges the pruned edge weights with their error nodes.

The notebook demonstrates:
- Graph Scores
- Pruned Graph Scores (zeros out the pruned edges/nodes)
- Subgraph Scores (merges the non-selected edges/nodes into error nodes)

The user should pass the unpruned graph for the most accurate subgraph score, but in cases where we do not have that (eg on Neuronpedia where we only have the pruned graph), the notebook shows that the different is not huge if we pass the pruned graph.

Important to review:
- Check the logic in compute_subgraph_scores that I'm not borking something important. This was Claude (4.5) assisted!
- Check that my reasoning makes sense for pruned graph scores and subgraph scores.

I did a "sanity test" by checking 1 pinned node vs 22 pinned nodes, in the Gemma Dallas Austin graph

```
1 Pinned Node (node '21_5943_10')
Graph: replacement_score=0.7022231817245483, completeness_score=0.9187235832214355
Pruned graph: replacement_score=0.5541447997093201, completeness_score=0.8545156121253967
Subgraph: replacement_score=0.2105160355567932, completeness_score=0.6135198473930359

22 Pinned Nodes (the default subgraph in the demo)
Graph: replacement_score=0.7022683620452881, completeness_score=0.9187378287315369
Pruned graph: replacement_score=0.5542337894439697, completeness_score=0.8545501828193665
Subgraph: replacement_score=0.3058098256587982, completeness_score=0.7032272815704346
```

The results seem... fine? Is the replacement score expected to be so low?

Credit to @mntss, @hannamw, and @neverix for entertaining my various questions.