### PR TITLE
setting lazy_encoder/lazy_decoder and return_activations

### DIFF
--- a/circuit_tracer/replacement_model.py
+++ b/circuit_tracer/replacement_model.py
@@ -123,6 +123,8 @@ class ReplacementModel(HookedTransformer):
         transcoder_set: str,
         device: torch.device | None = None,
         dtype: torch.dtype = torch.float32,
+        lazy_encoder: bool = False,
+        lazy_decoder: bool = True,
         **kwargs,
     ) -> "ReplacementModel":
         """Create a ReplacementModel from model name and transcoder config
@@ -130,6 +132,15 @@ class ReplacementModel(HookedTransformer):
         Args:
             model_name (str): the name of the pretrained HookedTransformer
             transcoder_set (str): Either a predefined transcoder set name, or a config file
+            device (torch.device | None): The device to load the model and transcoders on.
+                If None, uses the default device. Defaults to None.
+            dtype (torch.dtype): The dtype to use for the model and transcoders.
+                Defaults to torch.float32.
+            lazy_encoder (bool): Whether to lazily load encoder weights. If True, encoder
+                weights are not loaded into memory until needed. Defaults to False.
+            lazy_decoder (bool): Whether to lazily load decoder weights. If True, decoder
+                weights are not loaded into memory until needed. Defaults to True.
+            **kwargs: Additional keyword arguments passed to HookedTransformer.from_pretrained
 
         Returns:
             ReplacementModel: The loaded ReplacementModel
@@ -137,7 +148,11 @@ class ReplacementModel(HookedTransformer):
         if device is None:
             device = get_default_device()
 
-        transcoders, _ = load_transcoder_from_hub(transcoder_set, device=device, dtype=dtype)
+        transcoders, _ = load_transcoder_from_hub(transcoder_set, 
+                                                  device=device, 
+                                                  dtype=dtype, 
+                                                  lazy_encoder=lazy_encoder, 
+                                                  lazy_decoder=lazy_decoder)
 
         return cls.from_pretrained_and_transcoders(
             model_name,
@@ -530,6 +545,8 @@ class ReplacementModel(HookedTransformer):
         apply_activation_function: bool = True,
         sparse: bool = False,
         using_past_kv_cache: bool = False,
+        return_activations: bool = True,
+
     ):
         """Given the input, and a dictionary of features to intervene on, performs the
         intervention, allowing all effects to propagate (optionally allowing its effects to
@@ -553,6 +570,10 @@ class ReplacementModel(HookedTransformer):
             using_past_kv_cache (bool): whether we are generating with past_kv_cache, meaning that
                 n_pos is 1, and we must append onto the existing logit / activation cache if the
                 hooks are run multiple times. Defaults to False
+            return_activations (bool): Whether to compute and return feature activations. If False,
+                activation computation is skipped for layers not being intervened on (when
+                constrained_layers is not set), saving time. Activations are not returned.
+                Defaults to True.
         """
 
         interventions_by_layer = defaultdict(list)
@@ -587,6 +608,15 @@ class ReplacementModel(HookedTransformer):
             sparse=sparse,
             append=using_past_kv_cache,
         )
+
+        if not return_activations:
+            new_activation_hooks = []
+            if not constrained_layers:
+                for loc, hook in activation_hooks:
+                    layer = int(loc.split('.')[1])
+                    if layer in interventions_by_layer:
+                        new_activation_hooks.append((loc, hook))
+            activation_hooks = new_activation_hooks
 
         def calculate_delta_hook(activations, hook, layer: int, layer_interventions):
             if constrained_layers:
@@ -681,7 +711,8 @@ class ReplacementModel(HookedTransformer):
         freeze_attention: bool = True,
         apply_activation_function: bool = True,
         sparse: bool = False,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return_activations: bool = True,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Given the input, and a dictionary of features to intervene on, performs the
         intervention, and returns the logits and feature activations. If freeze_attention or
         constrained_layers is True, attention patterns will be frozen, along with MLPs and
@@ -705,6 +736,10 @@ class ReplacementModel(HookedTransformer):
                 feature values.
             sparse (bool): whether to sparsify the activations in the returned cache. Setting
                 this to True will take up less memory, at the expense of slower interventions.
+            return_activations (bool): Whether to compute and return feature activations. If False,
+                activation computation is skipped for layers not being intervened on (when
+                constrained_layers is not set), saving time. Returns None for activations.
+                Defaults to True.
         """
 
         hooks, _, activation_cache = self._get_feature_intervention_hooks(
@@ -714,12 +749,16 @@ class ReplacementModel(HookedTransformer):
             freeze_attention=freeze_attention,
             apply_activation_function=apply_activation_function,
             sparse=sparse,
+            return_activations=return_activations,
         )
 
         with self.hooks(hooks):  # type: ignore
             logits = self(inputs)
 
-        activation_cache = torch.stack(activation_cache)
+        if return_activations:
+            activation_cache = torch.stack(activation_cache)
+        else:
+            activation_cache = None
 
         return logits, activation_cache
 
@@ -750,8 +789,9 @@ class ReplacementModel(HookedTransformer):
         freeze_attention: bool = True,
         apply_activation_function: bool = True,
         sparse: bool = False,
+        return_activations: bool = True,
         **kwargs,
-    ) -> tuple[str, torch.Tensor, torch.Tensor]:
+    ) -> tuple[str, torch.Tensor, torch.Tensor | None]:
         """Given the input, and a dictionary of features to intervene on, performs the
         intervention, and generates a continuation, along with the logits and activations at
         each generation position.
@@ -785,6 +825,10 @@ class ReplacementModel(HookedTransformer):
                 feature values.
             sparse (bool): whether to sparsify the activations in the returned cache. Setting
                 this to True will take up less memory, at the expense of slower interventions.
+            return_activations (bool): Whether to compute and return feature activations. If False,
+                activation computation is skipped for layers not being intervened on (when
+                constrained_layers is not set), saving time. Returns None for activations.
+                Defaults to True.
         """
 
         feature_intervention_hook_output = self._get_feature_intervention_hooks(
@@ -794,6 +838,7 @@ class ReplacementModel(HookedTransformer):
             freeze_attention=freeze_attention,
             apply_activation_function=apply_activation_function,
             sparse=sparse,
+            return_activations=return_activations,
         )
 
         hooks, logit_cache, activation_cache = feature_intervention_hook_output
@@ -816,6 +861,7 @@ class ReplacementModel(HookedTransformer):
                 apply_activation_function=apply_activation_function,
                 sparse=sparse,
                 using_past_kv_cache=True,
+                return_activations=return_activations,
             )
         )
 
@@ -838,10 +884,21 @@ class ReplacementModel(HookedTransformer):
             [torch.cat(acts, dim=0) for acts in open_ended_activations],  # type:ignore
             dim=0,
         )
-        activation_cache = torch.stack(activation_cache)
-        activations = torch.cat((activation_cache, open_ended_activations), dim=1)
-        if sparse:
-            activations = activations.coalesce()
+        if return_activations:
+            activation_cache = torch.stack(activation_cache)
+            if open_ended_activations and any(acts for acts in open_ended_activations):
+                open_ended_activations = torch.stack(
+                    [torch.cat(acts, dim=0) for acts in open_ended_activations],  # type:ignore
+                    dim=0,
+                )
+                
+                activations = torch.cat((activation_cache, open_ended_activations), dim=1)
+            else:
+                activations = activation_cache
+            if sparse:
+                activations = activations.coalesce()
+        else:
+            activations = None
 
         return generation, logits, activations
 

--- a/demos/graph_visualization.py
+++ b/demos/graph_visualization.py
@@ -1,6 +1,5 @@
 # %%
 from collections import namedtuple
-from typing import List, Optional, Tuple, Dict
 import math
 import html
 
@@ -13,10 +12,10 @@ Feature = namedtuple("Feature", ["layer", "pos", "feature_idx"])
 
 class InterventionGraph:
     prompt: str
-    ordered_nodes: List["Supernode"]
-    nodes: Dict[str, "Supernode"]
+    ordered_nodes: list["Supernode"]
+    nodes: dict[str, "Supernode"]
 
-    def __init__(self, ordered_nodes: List["Supernode"], prompt: str):
+    def __init__(self, ordered_nodes: list["Supernode"], prompt: str):
         self.ordered_nodes = ordered_nodes
         self.prompt = prompt
         self.nodes = {}
@@ -47,17 +46,17 @@ class Supernode:
     name: str
     activation: float | None
     default_activations: torch.Tensor | None
-    children: List["Supernode"]
+    children: list["Supernode"]
     intervention: None
-    replacement_node: Optional["Supernode"]
+    replacement_node: "Supernode | None"
 
     def __init__(
         self,
         name: str,
-        features: List[Feature],
-        children: List["Supernode"] = [],
-        intervention: Optional[str] = None,
-        replacement_node: Optional["Supernode"] = None,
+        features: list[Feature],
+        children: list["Supernode"] = [],
+        intervention: str | None = None,
+        replacement_node: "Supernode | None" = None,
     ):
         self.name = name
         self.features = features
@@ -71,7 +70,7 @@ class Supernode:
         return f"Node(name={self.name}, activation={self.activation}, children={self.children}, intervention={self.intervention}, replacement_node={self.replacement_node})"
 
 
-def calculate_node_positions(nodes: List[List["Supernode"]]):
+def calculate_node_positions(nodes: list[list["Supernode"]]):
     """Calculate positions for all nodes including replacements"""
     container_width = 600
     container_height = 250
@@ -278,7 +277,7 @@ def create_nodes_svg(node_data):
     return "\n".join(svg_parts)
 
 
-def build_connections_data(nodes: List[List["Supernode"]]):
+def build_connections_data(nodes: list[list["Supernode"]]):
     """Build connection data from node relationships"""
     connections = []
 
@@ -345,7 +344,7 @@ def wrap_text_for_svg(text, max_width=80):
 
 
 def create_graph_visualization(
-    intervention_graph: InterventionGraph, top_outputs: List[Tuple[str, float]]
+    intervention_graph: InterventionGraph, top_outputs: list[tuple[str, float]]
 ):
     """
     Creates an SVG-based graph visualization that renders properly on GitHub and other platforms.

--- a/tests/test_attribution_clt.py
+++ b/tests/test_attribution_clt.py
@@ -80,6 +80,7 @@ def verify_feature_edges(
         )
         new_logits = new_logits.squeeze(0)
 
+        assert new_activation_cache is not None
         new_relevant_activations = new_activation_cache[
             active_features[:, 0], active_features[:, 1], active_features[:, 2]
         ]

--- a/tests/test_attributions_gemma.py
+++ b/tests/test_attributions_gemma.py
@@ -142,6 +142,7 @@ def verify_feature_edges(
         )
         new_logits = new_logits.squeeze(0)
 
+        assert new_activation_cache is not None
         new_relevant_activations = new_activation_cache[
             active_features[:, 0], active_features[:, 1], active_features[:, 2]
         ]

--- a/tests/test_interventions.py
+++ b/tests/test_interventions.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from circuit_tracer import ReplacementModel
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_intervention_return_activations():
+    model = ReplacementModel.from_pretrained("google/gemma-2-2b", 
+                                             "gemma")
+
+    s = "The National Digital Analytics Group (ND"
+
+    interventions = [(21, 7, 5066, 0.0)]
+
+    logits_with_activations, activations = model.feature_intervention(
+        s,
+        interventions,
+        constrained_layers=range(model.cfg.n_layers),
+        return_activations=True,
+    )
+
+    logits_without_activations, no_activations = model.feature_intervention(
+        s,
+        interventions,
+        constrained_layers=range(model.cfg.n_layers),
+        return_activations=False,
+    )
+
+    assert torch.allclose(
+        logits_with_activations, logits_without_activations, atol=1e-6, rtol=1e-5
+    ), "Logits should be identical regardless of return_activations setting"
+
+    assert activations is not None, "Activations should be returned when return_activations=True"
+    assert no_activations is None, "Activations should be None when return_activations=False"
+
+
+if __name__ == "__main__":
+    torch.manual_seed(42)
+    test_intervention_return_activations()
+


### PR DESCRIPTION
This PR adds in the ability to set lazy_encoder/ lazy_decoder when using `ReplacementModel.from_pretrained`. It also adds in a `return_activations` argument to intervention functions (default: `True`). When `False`, `None` is returned instead of activations, and activations are not computed except where necessary for the intervention. This allows for much faster interventions.