### PR TITLE
setting lazy_encoder/lazy_decoder and return_activations, typing

### DIFF
--- a/demos/graph_visualization.py
+++ b/demos/graph_visualization.py
@@ -1,6 +1,5 @@
 # %%
 from collections import namedtuple
-from typing import List, Optional, Tuple, Dict
 import math
 import html
 
@@ -13,10 +12,10 @@ Feature = namedtuple("Feature", ["layer", "pos", "feature_idx"])
 
 class InterventionGraph:
     prompt: str
-    ordered_nodes: List["Supernode"]
-    nodes: Dict[str, "Supernode"]
+    ordered_nodes: list["Supernode"]
+    nodes: dict[str, "Supernode"]
 
-    def __init__(self, ordered_nodes: List["Supernode"], prompt: str):
+    def __init__(self, ordered_nodes: list["Supernode"], prompt: str):
         self.ordered_nodes = ordered_nodes
         self.prompt = prompt
         self.nodes = {}
@@ -47,17 +46,17 @@ class Supernode:
     name: str
     activation: float | None
     default_activations: torch.Tensor | None
-    children: List["Supernode"]
+    children: list["Supernode"]
     intervention: None
-    replacement_node: Optional["Supernode"]
+    replacement_node: "Supernode | None"
 
     def __init__(
         self,
         name: str,
-        features: List[Feature],
-        children: List["Supernode"] = [],
-        intervention: Optional[str] = None,
-        replacement_node: Optional["Supernode"] = None,
+        features: list[Feature],
+        children: list["Supernode"] = [],
+        intervention: str | None = None,
+        replacement_node: "Supernode | None" = None,
     ):
         self.name = name
         self.features = features
@@ -71,7 +70,7 @@ class Supernode:
         return f"Node(name={self.name}, activation={self.activation}, children={self.children}, intervention={self.intervention}, replacement_node={self.replacement_node})"
 
 
-def calculate_node_positions(nodes: List[List["Supernode"]]):
+def calculate_node_positions(nodes: list[list["Supernode"]]):
     """Calculate positions for all nodes including replacements"""
     container_width = 600
     container_height = 250
@@ -278,7 +277,7 @@ def create_nodes_svg(node_data):
     return "\n".join(svg_parts)
 
 
-def build_connections_data(nodes: List[List["Supernode"]]):
+def build_connections_data(nodes: list[list["Supernode"]]):
     """Build connection data from node relationships"""
     connections = []
 
@@ -345,7 +344,7 @@ def wrap_text_for_svg(text, max_width=80):
 
 
 def create_graph_visualization(
-    intervention_graph: InterventionGraph, top_outputs: List[Tuple[str, float]]
+    intervention_graph: InterventionGraph, top_outputs: list[tuple[str, float]]
 ):
     """
     Creates an SVG-based graph visualization that renders properly on GitHub and other platforms.

--- a/tests/test_attribution_clt.py
+++ b/tests/test_attribution_clt.py
@@ -80,6 +80,7 @@ def verify_feature_edges(
         )
         new_logits = new_logits.squeeze(0)
 
+        assert new_activation_cache is not None
         new_relevant_activations = new_activation_cache[
             active_features[:, 0], active_features[:, 1], active_features[:, 2]
         ]

--- a/tests/test_attributions_gemma.py
+++ b/tests/test_attributions_gemma.py
@@ -142,6 +142,7 @@ def verify_feature_edges(
         )
         new_logits = new_logits.squeeze(0)
 
+        assert new_activation_cache is not None
         new_relevant_activations = new_activation_cache[
             active_features[:, 0], active_features[:, 1], active_features[:, 2]
         ]

--- a/tests/test_interventions.py
+++ b/tests/test_interventions.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+from circuit_tracer import ReplacementModel
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_intervention_return_activations():
+    model = ReplacementModel.from_pretrained("google/gemma-2-2b", "gemma")
+
+    s = "The National Digital Analytics Group (ND"
+
+    interventions = [(21, 7, 5066, 0.0)]
+
+    logits_with_activations, activations = model.feature_intervention(
+        s,
+        interventions,
+        constrained_layers=range(model.cfg.n_layers),
+        return_activations=True,
+    )
+
+    logits_without_activations, no_activations = model.feature_intervention(
+        s,
+        interventions,
+        constrained_layers=range(model.cfg.n_layers),
+        return_activations=False,
+    )
+
+    assert torch.allclose(
+        logits_with_activations, logits_without_activations, atol=1e-6, rtol=1e-5
+    ), "Logits should be identical regardless of return_activations setting"
+
+    assert activations is not None, "Activations should be returned when return_activations=True"
+    assert no_activations is None, "Activations should be None when return_activations=False"
+
+
+if __name__ == "__main__":
+    torch.manual_seed(42)
+    test_intervention_return_activations()


### PR DESCRIPTION
This PR adds in the ability to set lazy_encoder/ lazy_decoder when using ReplacementModel.from_pretrained. It also adds in a return_activations argument to intervention functions (default: True). When False, None is returned instead of activations, and activations are not computed except where necessary for the intervention. This allows for much faster interventions.