### PR TITLE
Expand Range of GPUs Capable of Running Full Test Suite

### DIFF
--- a/tests/test_attributions_gemma.py
+++ b/tests/test_attributions_gemma.py
@@ -377,7 +377,7 @@ def verify_large_gemma_model(s: torch.Tensor):
 
 def verify_gemma_2_2b(s: str):
     model = ReplacementModel.from_pretrained("google/gemma-2-2b", "gemma")
-    graph = attribute(s, model)
+    graph = attribute(s, model, batch_size=256)
 
     print("Changing logit softcap to 0, as the logits will otherwise be off.")
     with model.zero_softcap():


### PR DESCRIPTION
## Expand Range of GPUs Capable of Running Full Test Suite

This tiny PR simply configures `test_gemma_2_2b` to use smaller non-default `batch_size` (similar to `verify_llama_3_2_1b`) in order to expand the range of gpus the test suite can successfully run on.

Keeping this PR separate from another two I've opened since the change is semantically unrelated and shouldn't be contingent on merging of the others.

Thanks!