### PR TITLE
Fix for `feature_intervention_generate()`

### DIFF
--- a/circuit_tracer/replacement_model.py
+++ b/circuit_tracer/replacement_model.py
@@ -881,10 +881,6 @@ class ReplacementModel(HookedTransformer):
         self.reset_hooks()
 
         logits = torch.cat((logit_cache[0], *open_ended_logits), dim=1)  # type:ignore
-        open_ended_activations = torch.stack(
-            [torch.cat(acts, dim=0) for acts in open_ended_activations],  # type:ignore
-            dim=0,
-        )
         if return_activations:
             activation_cache = torch.stack(activation_cache)
             if open_ended_activations and any(acts for acts in open_ended_activations):


### PR DESCRIPTION
There's a snippet of code that processes `open_ended_activations` that is currently repeated twice. I think it is meant to only run when `return_activations=True`. If `return_activations=False`, the first instance of the snippet errors out since the acts are empty, whereas if `return_activations=True`, the second instance errors out since the processing has already been done.

I was able to get generation working by removing the first snippet, so I think this is the intended behavior.