### PR TITLE
Fix: preserve device index in CrossLayerTranscoder lazy loading

### DIFF
--- a/circuit_tracer/transcoder/cross_layer_transcoder.py
+++ b/circuit_tracer/transcoder/cross_layer_transcoder.py
@@ -127,8 +127,8 @@ class CrossLayerTranscoder(torch.nn.Module):
         if layer_id is not None:
             # Load single layer encoder
             enc_file = os.path.join(self.clt_path, f"W_enc_{layer_id}.safetensors")
-            with safe_open(enc_file, framework="pt", device=self.device.type) as f:
-                return f.get_tensor(f"W_enc_{layer_id}").to(dtype=self.dtype, device=self.device)
+            with safe_open(enc_file, framework="pt", device=str(self.device)) as f:
+                return f.get_tensor(f"W_enc_{layer_id}").to(dtype=self.dtype)
 
         # Load all encoder weights
         W_enc = torch.zeros(
@@ -136,8 +136,8 @@ class CrossLayerTranscoder(torch.nn.Module):
         )
         for i in range(self.n_layers):
             enc_file = os.path.join(self.clt_path, f"W_enc_{i}.safetensors")
-            with safe_open(enc_file, framework="pt", device=self.device.type) as f:
-                W_enc[i] = f.get_tensor(f"W_enc_{i}").to(dtype=self.dtype, device=self.device)
+            with safe_open(enc_file, framework="pt", device=str(self.device)) as f:
+                W_enc[i] = f.get_tensor(f"W_enc_{i}").to(dtype=self.dtype)
         return W_enc
 
     def encode(self, x):
@@ -204,16 +204,14 @@ class CrossLayerTranscoder(torch.nn.Module):
 
         if not self.lazy_decoder:
             assert self.W_dec is not None, "Decoder weights are not set"
-            return self.W_dec[layer_id][to_read].to(dtype=self.dtype, device=self.device)
+            return self.W_dec[layer_id][to_read].to(dtype=self.dtype)
 
         assert self.clt_path is not None, "CLT path is not set"
         path = os.path.join(self.clt_path, f"W_dec_{layer_id}.safetensors")
         if isinstance(to_read, torch.Tensor):
             to_read = to_read.cpu()
-        with safe_open(path, framework="pt", device=self.device.type) as f:
-            return f.get_slice(f"W_dec_{layer_id}")[to_read].to(
-                dtype=self.dtype, device=self.device
-            )
+        with safe_open(path, framework="pt", device=str(self.device)) as f:
+            return f.get_slice(f"W_dec_{layer_id}")[to_read].to(dtype=self.dtype)
 
     def select_decoder_vectors(self, features):
         if not features.is_sparse:
@@ -382,7 +380,7 @@ def _load_state_dict(
 
     # Get dimensions from first file
     dec_file = "W_enc_0.safetensors"
-    with safe_open(os.path.join(clt_path, dec_file), framework="pt", device=device.type) as f:
+    with safe_open(os.path.join(clt_path, dec_file), framework="pt", device=str(device)) as f:
         d_transcoder, d_model = f.get_slice("W_enc_0").get_shape()
         has_threshold = "threshold_0" in f.keys()
 
@@ -405,7 +403,7 @@ def _load_state_dict(
     # Load all layers
     for i in range(n_layers):
         enc_file = f"W_enc_{i}.safetensors"
-        with safe_open(os.path.join(clt_path, enc_file), framework="pt", device=device.type) as f:
+        with safe_open(os.path.join(clt_path, enc_file), framework="pt", device=str(device)) as f:
             b_dec[i] = f.get_tensor(f"b_dec_{i}").to(dtype)
             b_enc[i] = f.get_tensor(f"b_enc_{i}").to(dtype)
 
@@ -420,7 +418,7 @@ def _load_state_dict(
         # Load W_dec for this layer if not lazy
         if not lazy_decoder:
             dec_file = os.path.join(clt_path, f"W_dec_{i}.safetensors")
-            with safe_open(dec_file, framework="pt", device=device.type) as f:
+            with safe_open(dec_file, framework="pt", device=str(device)) as f:
                 state_dict[f"W_dec.{i}"] = f.get_tensor(f"W_dec_{i}").to(dtype)
 
     return state_dict

--- a/circuit_tracer/transcoder/single_layer_transcoder.py
+++ b/circuit_tracer/transcoder/single_layer_transcoder.py
@@ -95,10 +95,10 @@ class SingleLayerTranscoder(nn.Module):
         """Dynamically load weights when accessed if lazy loading is enabled."""
 
         if name == "W_enc" and self.lazy_encoder and self.transcoder_path is not None:
-            with safe_open(self.transcoder_path, framework="pt", device=self.device.type) as f:
+            with safe_open(self.transcoder_path, framework="pt", device=str(self.device)) as f:
                 return f.get_tensor("W_enc").to(self.dtype)
         elif name == "W_dec" and self.lazy_decoder and self.transcoder_path is not None:
-            with safe_open(self.transcoder_path, framework="pt", device=self.device.type) as f:
+            with safe_open(self.transcoder_path, framework="pt", device=str(self.device)) as f:
                 return f.get_tensor("W_dec").to(self.dtype)
 
         return super().__getattr__(name)
@@ -110,7 +110,7 @@ class SingleLayerTranscoder(nn.Module):
 
         if isinstance(to_read, torch.Tensor):
             to_read = to_read.cpu()
-        with safe_open(self.transcoder_path, framework="pt", device=self.device.type) as f:
+        with safe_open(self.transcoder_path, framework="pt", device=str(self.device)) as f:
             return f.get_slice("W_dec")[to_read].to(self.dtype)
 
     def encode(self, input_acts, apply_activation_function: bool = True):
@@ -391,7 +391,7 @@ def load_relu_transcoder(
         device = get_default_device()
 
     param_dict = {}
-    with safe_open(path, framework="pt", device=device.type) as f:
+    with safe_open(path, framework="pt", device=str(device)) as f:
         for k in f.keys():
             if lazy_encoder and k == "W_enc":
                 continue


### PR DESCRIPTION
# What is the current behavior? 
When initializing `CrossLayerTranscoder` with a specific device index (e.g., `device="cuda:1"`) AND enabling `lazy_decoder` or `lazy_encoder`, the sub-modules are loaded onto the wrong device.
This happens because the code was accessing `self.device.type` (which returns just `"cuda"`) instead of the full device object or string. This strips away the device index information, causing tensors/models to fall back to the default device (usually `cuda:0`).
# What is the new behavior? 
I updated the logic to use `self.device` (or the correct device string) during the lazy loading process. This ensures that if a user specifies `cuda:1`, the encoder/decoder is correctly initialized on `cuda:1`.

# Steps to reproduce
```python
import torch
from circuit_tracer.transcoder.cross_layer_transcoder import load_clt
from transformers import AutoModelForCausalLM, AutoTokenizer
from circuit_tracer.replacement_model import ReplacementModel
from circuit_tracer.attribution.attribute import attribute

model_path = "/PATH/TO/gemma-2-2b"
clt_path = "/PATH/TO/clt-gemma-2-2b-426k"
device = torch.device("cuda:1")
dtype = torch.bfloat16

clt = load_clt(
    clt_path,
    device=device,
    dtype=dtype,
    lazy_decoder=True,
    lazy_encoder=True,
)


hf_model = AutoModelForCausalLM.from_pretrained(
    model_path,
    torch_dtype=dtype,
)

tokenizer = AutoTokenizer.from_pretrained(model_path)
tokenizer.padding_side = "left"
if tokenizer.pad_token_id is None:
    tokenizer.pad_token_id = tokenizer.eos_token_id


model = ReplacementModel.from_pretrained_and_transcoders(
    model_name="google/gemma-2-2b",
    transcoders=clt,
    hf_model=hf_model,
    tokenizer=tokenizer,
    device=device,
    dtype=dtype,
    default_prepend_bos=True,
    default_padding_side="left",
)

prompt = "The capital of France is Paris."

graph = attribute(
    model=model,
    prompt=prompt,
    max_n_logits=5,
    desired_logit_prob=0.9,
    batch_size=64,
    max_feature_nodes=100,
    offload=None,
    verbose=False,
)

# Run Result: RuntimeError: Expected all tensors to be on the same device, but got mat2 is on cuda:0, different from other tensors on cuda:1 (when checking argument in method wrapper_CUDA_bmm)
```