### PR TITLE
gemma_demo.ipynb import fix

### DIFF
--- a/demos/gemma_demo.ipynb
+++ b/demos/gemma_demo.ipynb
@@ -80,7 +80,7 @@
     "from circuit_tracer.replacement_model import ReplacementModel\n",
     "\n",
     "from circuit_tracer.utils.decode_url_features import decode_url_features\n",
-    "from url import display_topk_token_predictions, display_generations_comparison"
+    "from utils import display_topk_token_predictions, display_generations_comparison"
    ]
   },
   {


### PR DESCRIPTION
Fixing an import gemma_demo.ipynb, by changing it from `from url` to `from utils`.