### PR TITLE
Error node fix

### DIFF
--- a/circuit_tracer/replacement_model/replacement_model_nnsight.py
+++ b/circuit_tracer/replacement_model/replacement_model_nnsight.py
@@ -541,7 +541,7 @@ class NNSightReplacementModel(LanguageModel):
         # Compute error vectors
         error_vectors = mlp_out_cache - attribution_data["reconstruction"]
 
-        error_vectors[:, 0] = 0
+        error_vectors[:, zero_positions] = 0
         token_vectors = self.embed_weight[  # type: ignore
             tokens
         ].detach()  # (n_pos, d_model)  # type: ignore

--- a/tests/test_attributions_llama.py
+++ b/tests/test_attributions_llama.py
@@ -225,8 +225,22 @@ def test_llama_3_2_1b():
     verify_feature_edges(model, graph)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_llama_3_2_1b_clt():
+    s = "The National Digital Analytics Group (ND"
+    model = ReplacementModel.from_pretrained(
+        "meta-llama/Llama-3.2-1B", "mntss/clt-llama-3.2-1b-524k"
+    )
+    assert isinstance(model, TransformerLensReplacementModel)
+    graph = attribute(s, model, batch_size=128)
+
+    verify_token_and_error_edges(model, graph)
+    verify_feature_edges(model, graph)
+
+
 if __name__ == "__main__":
     torch.manual_seed(42)
     test_small_llama_model()
     test_large_llama_model()
     test_llama_3_2_1b()
+    test_llama_3_2_1b_clt()


### PR DESCRIPTION
Fixes two bugs:
1. Error nodes for skip transcoders were computed without accounting for the skip connection, resulting in inflated errors
2. Error nodes for gemma-3 instruct models were only being zeroed out at position 0, rather than at the first 4 positions (corresponding to the 4 static BOS-adjacent tokens that their transcoders were not trained on)