### PR TITLE
Error Node Fixes

### DIFF
--- a/circuit_tracer/replacement_model/replacement_model_nnsight.py
+++ b/circuit_tracer/replacement_model/replacement_model_nnsight.py
@@ -303,7 +303,7 @@ class NNSightReplacementModel(LanguageModel):
             gemma_3_it = "gemma-3" in self.cfg.model_name and self.cfg.model_name.endswith("-it")
             overlap = 0
             if gemma_3_it:
-                input_ids = self.input.squeeze(0)
+                input_ids = self.input
                 ignore_prefix = torch.tensor(
                     [2, 105, 2364, 107], dtype=input_ids.dtype, device=input_ids.device
                 )
@@ -541,7 +541,7 @@ class NNSightReplacementModel(LanguageModel):
         # Compute error vectors
         error_vectors = mlp_out_cache - attribution_data["reconstruction"]
 
-        error_vectors[:, 0] = 0
+        error_vectors[:, zero_positions] = 0
         token_vectors = self.embed_weight[  # type: ignore
             tokens
         ].detach()  # (n_pos, d_model)  # type: ignore

--- a/tests/test_attributions_gemma3_nnsight.py
+++ b/tests/test_attributions_gemma3_nnsight.py
@@ -149,13 +149,13 @@ def verify_token_and_error_edges(
     act_rtol=1e-3,
     logit_atol=1e-5,
     logit_rtol=1e-3,
+    pos_start=1,
 ):
     s = graph.input_tokens
     adjacency_matrix = graph.adjacency_matrix.to(device=model.device, dtype=model.dtype)
     active_features = graph.active_features.to(device=model.device)
     logit_tokens = graph.logit_tokens.to(device=model.device)
     total_active_features = active_features.size(0)
-    pos_start = 1  # skip first position (BOS token)
 
     ctx = model.setup_attribution(s)
 
@@ -526,6 +526,24 @@ def test_gemma_3_1b():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_gemma_3_1b_it():
+    s = "<bos><start_of_turn>user\nThe National Digital Analytics Group (ND"
+    model = ReplacementModel.from_pretrained(
+        "google/gemma-3-1b-it",
+        "mwhanna/gemma-scope-2-1b-it/transcoder_all/width_16k_l0_small_affine",
+        dtype=torch.float32,
+        backend="nnsight",
+    )
+    graph = attribute(s, model)
+    assert isinstance(model, NNSightReplacementModel)
+
+    print("Changing logit softcap to 0, as the logits will otherwise be off.")
+    with model.zero_softcap():
+        verify_token_and_error_edges(model, graph, pos_start=4)
+        verify_feature_edges(model, graph)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_gemma_3_1b_clt():
     s = "The National Digital Analytics Group (ND"
     model = ReplacementModel.from_pretrained(
@@ -569,5 +587,6 @@ if __name__ == "__main__":
     test_gemma3_with_dummy_transcoders()
     test_gemma3_with_dummy_clt()
     test_gemma_3_1b()
+    test_gemma_3_1b_it()
     test_gemma_3_1b_clt()
     test_gemma_3_4b()

--- a/tests/test_attributions_llama.py
+++ b/tests/test_attributions_llama.py
@@ -225,8 +225,22 @@ def test_llama_3_2_1b():
     verify_feature_edges(model, graph)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_llama_3_2_1b_clt():
+    s = "The National Digital Analytics Group (ND"
+    model = ReplacementModel.from_pretrained(
+        "meta-llama/Llama-3.2-1B", "mntss/clt-llama-3.2-1b-524k"
+    )
+    assert isinstance(model, TransformerLensReplacementModel)
+    graph = attribute(s, model, batch_size=128)
+
+    verify_token_and_error_edges(model, graph)
+    verify_feature_edges(model, graph)
+
+
 if __name__ == "__main__":
     torch.manual_seed(42)
     test_small_llama_model()
     test_large_llama_model()
     test_llama_3_2_1b()
+    test_llama_3_2_1b_clt()


### PR DESCRIPTION
Fixes two bugs:
- Error nodes for skip transcoders were computed without accounting for the skip connection, resulting in inflated errors
- Error nodes for gemma-3 instruct models were only being zeroed out at position 0, rather than at the first 4 positions (corresponding to the 4 static BOS-adjacent tokens that their transcoders were not trained on)