### PR TITLE
Fix batched get_activations zero-position masking

### DIFF
--- a/circuit_tracer/replacement_model/_utils.py
+++ b/circuit_tracer/replacement_model/_utils.py
@@ -1,0 +1,19 @@
+import torch
+
+
+def zero_special_positions(
+    activations: torch.Tensor,
+    zero_positions: int | slice,
+) -> torch.Tensor:
+    """Zero special-token positions on the position axis for single or batched activations."""
+
+    if activations.ndim < 2:
+        raise ValueError(
+            f"Expected activations with at least 2 dimensions, got shape {tuple(activations.shape)}"
+        )
+
+    if activations.ndim == 2:
+        activations[zero_positions, :] = 0
+    else:
+        activations[:, zero_positions, :] = 0
+    return activations

--- a/circuit_tracer/replacement_model/replacement_model_nnsight.py
+++ b/circuit_tracer/replacement_model/replacement_model_nnsight.py
@@ -12,6 +12,7 @@ from nnsight.intervention.tracing.tracer import Barrier
 from nnsight import LanguageModel, Envoy, save, CONFIG as NNSIGHT_CONFIG
 
 from circuit_tracer.attribution.context_nnsight import AttributionContext
+from circuit_tracer.replacement_model._utils import zero_special_positions
 from circuit_tracer.transcoder import TranscoderSet
 from circuit_tracer.transcoder.cross_layer_transcoder import CrossLayerTranscoder
 from circuit_tracer.utils import get_default_device
@@ -322,7 +323,7 @@ class NNSightReplacementModel(LanguageModel):
                 )
 
                 if not (append and len(activation_matrix[layer]) > 0):  # type:ignore
-                    transcoder_acts[self.zero_positions] = 0
+                    zero_special_positions(transcoder_acts, self.zero_positions)
 
                 if sparse:
                     transcoder_acts = transcoder_acts.to_sparse()

--- a/circuit_tracer/replacement_model/replacement_model_transformerlens.py
+++ b/circuit_tracer/replacement_model/replacement_model_transformerlens.py
@@ -12,6 +12,7 @@ from transformer_lens import HookedTransformer, HookedTransformerConfig
 from transformer_lens.hook_points import HookPoint
 
 from circuit_tracer.attribution.context_transformerlens import AttributionContext
+from circuit_tracer.replacement_model._utils import zero_special_positions
 from circuit_tracer.transcoder import TranscoderSet
 from circuit_tracer.transcoder.cross_layer_transcoder import CrossLayerTranscoder
 from circuit_tracer.utils import get_default_device
@@ -292,7 +293,7 @@ class TransformerLensReplacementModel(HookedTransformer):
             )
 
             if not append:
-                transcoder_acts[self.zero_positions] = 0
+                zero_special_positions(transcoder_acts, self.zero_positions)
 
             if sparse:
                 transcoder_acts = transcoder_acts.to_sparse()

--- a/tests/test_replacement_model_batching.py
+++ b/tests/test_replacement_model_batching.py
@@ -1,0 +1,133 @@
+import gc
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from transformer_lens import HookedTransformerConfig
+
+from circuit_tracer import ReplacementModel
+from circuit_tracer.transcoder import SingleLayerTranscoder, TranscoderSet
+from circuit_tracer.transcoder.activation_functions import TopK
+
+
+@pytest.fixture(autouse=True)
+def cleanup_cuda():
+    yield
+    torch.cuda.empty_cache()
+    gc.collect()
+
+
+def load_dummy_llama_replacement_model():
+    cfg = HookedTransformerConfig.from_dict(
+        {
+            "n_layers": 2,
+            "d_model": 32,
+            "n_ctx": 32,
+            "d_head": 8,
+            "model_name": "Llama-3.2-1B",
+            "n_heads": 4,
+            "d_mlp": 64,
+            "act_fn": "silu",
+            "d_vocab": 128,
+            "eps": 1e-05,
+            "use_attn_result": False,
+            "use_attn_scale": True,
+            "attn_scale": np.float64(8.0),
+            "use_split_qkv_input": False,
+            "use_hook_mlp_in": False,
+            "use_attn_in": False,
+            "use_local_attn": False,
+            "ungroup_grouped_query_attention": False,
+            "original_architecture": "LlamaForCausalLM",
+            "from_checkpoint": False,
+            "checkpoint_index": None,
+            "checkpoint_label_type": None,
+            "checkpoint_value": None,
+            "tokenizer_name": "gpt2",
+            "window_size": None,
+            "attn_types": None,
+            "init_mode": "gpt2",
+            "normalization_type": "RMSPre",
+            "device": "cpu",
+            "n_devices": 1,
+            "attention_dir": "causal",
+            "attn_only": False,
+            "seed": 42,
+            "initializer_range": np.float64(0.02),
+            "init_weights": True,
+            "scale_attn_by_inverse_layer_idx": False,
+            "positional_embedding_type": "rotary",
+            "final_rms": True,
+            "d_vocab_out": 128,
+            "parallel_attn_mlp": False,
+            "rotary_dim": 8,
+            "n_params": 123456,
+            "use_hook_tokens": False,
+            "gated_mlp": True,
+            "default_prepend_bos": True,
+            "dtype": torch.float32,
+            "tokenizer_prepends_bos": True,
+            "n_key_value_heads": 4,
+            "post_embedding_ln": False,
+            "rotary_base": 500000.0,
+            "trust_remote_code": False,
+            "rotary_adjacent_pairs": False,
+            "load_in_4bit": False,
+            "num_experts": None,
+            "experts_per_token": None,
+            "relative_attention_max_distance": None,
+            "relative_attention_num_buckets": None,
+            "decoder_start_token_id": None,
+            "tie_word_embeddings": False,
+            "use_normalization_before_and_after": False,
+            "attn_scores_soft_cap": -1.0,
+            "output_logits_soft_cap": -1.0,
+            "use_NTK_by_parts_rope": True,
+            "NTK_by_parts_low_freq_factor": 1.0,
+            "NTK_by_parts_high_freq_factor": 4.0,
+            "NTK_by_parts_factor": 32.0,
+        }
+    )
+
+    transcoders = {
+        layer_idx: SingleLayerTranscoder(
+            cfg.d_model, cfg.d_model * 2, TopK(8), layer_idx, skip_connection=True
+        )
+        for layer_idx in range(cfg.n_layers)
+    }
+    for transcoder in transcoders.values():
+        for _, param in transcoder.named_parameters():
+            nn.init.uniform_(param, a=-0.1, b=0.1)
+
+    model = ReplacementModel.from_config(
+        cfg,
+        TranscoderSet(
+            transcoders,
+            feature_input_hook="mlp.hook_in",
+            feature_output_hook="mlp.hook_out",
+        ),
+    )
+    return model
+
+
+def test_get_activations_batch_matches_single_tensor_runs():
+    model = load_dummy_llama_replacement_model()
+    batched_tokens = torch.tensor([[1, 2, 3, 4], [1, 5, 6, 7]], dtype=torch.long)
+
+    batched_logits, batched_activations = model.get_activations(batched_tokens)
+
+    for batch_idx in range(batched_tokens.size(0)):
+        single_logits, single_activations = model.get_activations(
+            batched_tokens[batch_idx : batch_idx + 1]
+        )
+
+        assert torch.allclose(
+            batched_logits[batch_idx], single_logits[0], atol=1e-6, rtol=1e-5
+        ), f"Logits diverged for sample {batch_idx}"
+        assert torch.allclose(
+            batched_activations[:, batch_idx],
+            single_activations,
+            atol=1e-6,
+            rtol=1e-5,
+        ), f"Activations diverged for sample {batch_idx}"


### PR DESCRIPTION
## Summary
- fix zero-position masking for batched activation caches by applying the mask on the position axis instead of the batch axis
- share the masking logic across the TransformerLens and NNSight ReplacementModel backends
- add a CPU regression test that compares batched tensor get_activations results against per-sample runs on a dummy ReplacementModel

## Motivation
While investigating #67, I found a concrete batching bug in get_activations(...): when the cached transcoder activations had shape (batch, pos, feature), self.zero_positions was being applied to the first axis, which zeroed batch entries instead of token positions. This produced batch-vs-single activation mismatches even when logits matched.

This PR fixes that narrower correctness issue without claiming to resolve the entire large-model ReplacementModel parity issue in #67.

## Testing
- python -m ruff check circuit_tracer/replacement_model/_utils.py circuit_tracer/replacement_model/replacement_model_transformerlens.py circuit_tracer/replacement_model/replacement_model_nnsight.py tests/test_replacement_model_batching.py
- python -m pyright circuit_tracer/replacement_model/_utils.py tests/test_replacement_model_batching.py
- python -m pytest -q tests/test_attributions_llama.py::test_small_llama_model tests/test_attributions_llama.py::test_large_llama_model tests/test_replacement_model_batching.py

Related to #67
