### PR TITLE
Add support for loading local CLT features in attribution graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ It will tell you where the server is serving (something like `localhost:[port]`)
 - `--transcoder_set` (`-t`): The set of transcoders to use for attribution. Options:
   - HuggingFace repository ID (e.g., `mntss/gemma-scope-transcoders`, `username/repo-name@revision`)
   - Convenience shortcuts: `gemma` (GemmaScope transcoders) or `llama` (ReLU transcoders)
+  - Path to locally saved transcoders: `/path/to/local_transcoders/`
 
 **Graph File Creation**
 
@@ -130,6 +131,7 @@ You must set `--slug` and `--graph_file_dir`, or `--graph_output_path`, or both!
 
 **Server Parameters:**
 - `--port` (default: 8041): Port for the local server
+- `--features_dir`: (default: None) Path to the directory containing feature files for local server, if using local transcoders
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You must set `--slug` and `--graph_file_dir`, or `--graph_output_path`, or both!
 
 **Server Parameters:**
 - `--port` (default: 8041): Port for the local server
-- `--features_dir`: (default: None) Path to the directory containing feature files for local server, if using local transcoders
+- `--features_dir` (default: None): Path to the directory containing feature files for local server, if using local transcoders
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ We also provide a number of annotated attribution graphs for both models, which 
 
 ## Usage
 ### Available Transcoders
+
+**On HuggingFace**
+
 The following transcoders are available for use with `circuit-tracer`; this means that the transcoder weights and features are both available (so features will load properly when you run the visualization server). You can use the HuggingFace repo name (e.g. `mntss/gemma-scope-transcoders`) as the `transcoders` argument of `ReplacementModel.from_pretrained`, or as the argument of `--transcoder_set` in the CLI. 
 - Gemma-2 (2B): [PLTs](https://huggingface.co/mntss/gemma-scope-transcoders) (originally from [GemmaScope](https://huggingface.co/google/gemma-scope)) and CLTs with 2 feature counts: [426K](https://huggingface.co/mntss/clt-gemma-2-2b-426k) and [2.5M](https://huggingface.co/mntss/clt-gemma-2-2b-2.5M)
 - Llama-3.2 (1B): [PLTs](https://huggingface.co/mntss/transcoder-Llama-3.2-1B) and [CLTs](https://huggingface.co/mntss/clt-llama-3.2-1b-524k)
@@ -46,6 +49,11 @@ The following transcoders are available for use with `circuit-tracer`; this mean
 - [GPT-OSS (20B) CLT](https://huggingface.co/mntss/clt-131k)
 - Gemma-3 PLTs (originally from [GemmaScope-2](https://huggingface.co/google/gemma-scope-2)) can be found [here for models of size 270M, 1B, 4B, 12B, and 27B, PT and IT](https://huggingface.co/collections/mwhanna/gemma-scope-2-transcoders-circuit-tracer). These require using the `nnsight` backend.
 
+**Locally Saved Transcoders**
+
+Locally saved transcoders can be loaded by using `ReplacementModel.from_pretrained` and including the full root path (not relative path) as the `transcoders` argument (e.g. `/path/to/local_transcoders/`). To enable feature visualizations in this case, you must direct the visualization server to the local feature data by setting the optional `features_dir` argument in `serve` to the same directory; for example: 
+
+`serve(data_dir=graph_path, port=port, features_dir='/path/to/local_transcoders/')`
 
 ### Choosing a Backend
 By default, `circuit-tracer` creates a `ReplacementModel` that inherits from the `TransformerLens` `HookedTransformer` class. However, `TransformerLens` does not support all HuggingFace models; it only supports those implemented in `TransformerLens`. 

--- a/circuit_tracer/__main__.py
+++ b/circuit_tracer/__main__.py
@@ -134,6 +134,12 @@ def main():
         help="Start a local server to visualize graphs after processing.",
     )
     attr_parser.add_argument("--port", type=int, default=8041, help="Port for the local server.")
+    attr_parser.add_argument(
+        "--features_dir",
+        type=str,
+        default=None,
+        help="Path to the directory containing feature files for local server, if using local transcoders (default: None)",
+    )
 
     # Start-server subcommand
     server_parser = subparsers.add_parser(
@@ -144,6 +150,12 @@ def main():
         type=str,
         required=True,
         help="Path to the directory containing graph JSON files.",
+    )
+    server_parser.add_argument(
+        "--features_dir",
+        type=str,
+        default=None,
+        help="Path to the directory containing feature files for local server, if using local transcoders (default: None)",
     )
     server_parser.add_argument("--port", type=int, default=8041, help="Port for the local server.")
 
@@ -264,7 +276,11 @@ def run_server(args):
 
     logging.info(f"Starting server on port {args.port}...")
     logging.info(f"Serving data from: {os.path.abspath(args.graph_file_dir)}")
-    server = serve(data_dir=args.graph_file_dir, port=args.port)
+    if args.features_dir:
+        if not os.path.isdir(args.features_dir):
+            raise ValueError(f"features_dir does not exist: {args.features_dir}")
+        logging.info(f"Using features directory: {os.path.abspath(args.features_dir)}")
+    server = serve(data_dir=args.graph_file_dir, port=args.port, features_dir=args.features_dir)
     try:
         logging.info("Press Ctrl+C to stop the server.")
         while True:

--- a/circuit_tracer/frontend/assets/feature_examples/init-feature-examples.js
+++ b/circuit_tracer/frontend/assets/feature_examples/init-feature-examples.js
@@ -42,7 +42,12 @@ window.initFeatureExamples = function({containerSel, showLogits=true, showExampl
     return feature
   }
 
-  function hfUrl(scan, path) {
+  function featureUrl(scan, path) {
+    // If the scan is a local path, fetch features from the local directory
+    if (scan.startsWith('/') || scan.startsWith('./')) {
+      return `/features/${path}`
+    }
+    // else create the HuggingFace url
     const [repoId, rest] = scan.split('//')
     const [filePath, revision] = rest ? rest.split('@') : [null, scan.split('@')[1]]
     const prefix = filePath ? `${filePath}/` : ''
@@ -52,7 +57,7 @@ window.initFeatureExamples = function({containerSel, showLogits=true, showExampl
   function indexFileExists(scan) {
     if (indexFileExistsCache.has(scan)) return indexFileExistsCache.get(scan)
     
-    const promise = fetch(hfUrl(scan, 'index.json.gz'), { method: 'HEAD' })
+    const promise = fetch(featureUrl(scan, 'index.json.gz'), { method: 'HEAD' })
       .then(response => response.ok)
       .catch(error => {
         if (error.status === 404) {
@@ -68,7 +73,7 @@ window.initFeatureExamples = function({containerSel, showLogits=true, showExampl
 
   async function loadFeatureFromBinary(scan, featureIndex) {
     const [layerIdx, featIdx] = util.cantorUnpair(featureIndex)
-    const indexData = await util.getFile(hfUrl(scan, 'index.json.gz'))
+    const indexData = await util.getFile(featureUrl(scan, 'index.json.gz'))
     const offsets = indexData[layerIdx]['offsets']
     const binFilename = indexData[layerIdx]['filename']
     const startByte = offsets[featIdx]
@@ -78,14 +83,14 @@ window.initFeatureExamples = function({containerSel, showLogits=true, showExampl
       throw new Error(`Feature ${featureIndex} not found in index`)
     }
 
-    return await util.getFile(hfUrl(scan, binFilename), true, 'bin', `bytes=${startByte}-${endByte}`)
+    return await util.getFile(featureUrl(scan, binFilename), true, 'bin', `bytes=${startByte}-${endByte}`)
   }
 
 
   async function loadFeature(scan, featureIndex){
     if (scan.startsWith('./')) {
       var feature = await  util.getFile(`${scan}/${featureIndex}.json`)
-    } else if (await indexFileExists(scan)){
+    } else if (scan.startsWith('/') || scan.startsWith('./') || await indexFileExists(scan)){
       var feature = await loadFeatureFromBinary(scan, featureIndex)
     } else {
       var feature = await  util.getFile(`./features/${scan}/${featureIndex}.json`)

--- a/circuit_tracer/frontend/local_server.py
+++ b/circuit_tracer/frontend/local_server.py
@@ -31,11 +31,12 @@ class ListHandler(logging.Handler):
 class ReusableTCPServer(socketserver.TCPServer):
     allow_reuse_address = True
 
-
-# Create handler for serving circuit graph data
+# Create handler for serving circuit graph data 
+# Local feature handling incorporated
 class CircuitGraphHandler(http.server.SimpleHTTPRequestHandler):
-    def __init__(self, *args, frontend_dir, data_dir, **kwargs):
+    def __init__(self, *args, frontend_dir, data_dir, features_dir, **kwargs):
         self.data_dir = data_dir
+        self.features_dir = features_dir
         super().__init__(*args, directory=str(frontend_dir), **kwargs)
 
     def log_message(self, format, *args):
@@ -55,6 +56,34 @@ class CircuitGraphHandler(http.server.SimpleHTTPRequestHandler):
     def _do_GET(self):
         logger.info(f"Received request for {self.path}")
 
+        if ((self.features_dir is not None) and (self.path.startswith('/features/'))):
+            rel_path = self.path[len('/features/'):].split('?')[0]
+            local_path = os.path.join(self.features_dir, rel_path)
+            if not os.path.exists(local_path):
+                self.send_response(404)
+                self.end_headers()
+                return
+            range_header = self.headers.get('Range', '')
+            with open(local_path, 'rb') as f:
+                if range_header.startswith('bytes='):
+                    file_size = os.path.getsize(local_path)
+                    start, end = range_header[6:].split('-')
+                    start = int(start)
+                    end = int(end) if end else file_size - 1
+                    f.seek(start)
+                    content = f.read(end - start + 1)
+                    self.send_response(206)
+                    self.send_header('Content-Range', f'bytes {start}-{end}/{file_size}')
+                else:
+                    content = f.read()
+                    self.send_response(200)
+            self.send_header('Content-Type', 'application/octet-stream')
+            self.send_header('Content-Length', str(len(content)))
+            self.send_header('Access-Control-Allow-Origin', '*')
+            self.end_headers()
+            self.wfile.write(content)
+            return
+    
         # Handle data and graph_data requests from local storage
         if self.path.startswith(("/data/", "/graph_data/")):
             # Extract the file path from the URL
@@ -188,13 +217,13 @@ class Server:
         """Return the current log messages."""
         return self.logs
 
-
-def serve(data_dir, frontend_dir=None, port=8032):
+def serve(data_dir, frontend_dir=None, features_dir=None, port=8032):
     """Start a local HTTP server in a separate thread.
 
     Args:
         data_dir: Directory for local graph data.
         frontend_dir: Directory containing frontend files. Defaults to DEFAULT_FRONTEND_DIR.
+        features_dir: If features are local, path to directory containing local feature files; else None. Defaults to None.
         port: Port to serve on. Defaults to 8032.
 
     Returns:
@@ -211,7 +240,7 @@ def serve(data_dir, frontend_dir=None, port=8032):
     logger.info(f"Serving files from: {frontend_dir}")
 
     # Create a partially applied handler class with configured directories
-    handler = functools.partial(CircuitGraphHandler, frontend_dir=frontend_dir, data_dir=data_dir)
+    handler = functools.partial(CircuitGraphHandler, frontend_dir=frontend_dir, data_dir=data_dir, features_dir=features_dir)
 
     httpd = ReusableTCPServer(("", port), handler)
 

--- a/circuit_tracer/frontend/local_server.py
+++ b/circuit_tracer/frontend/local_server.py
@@ -31,7 +31,8 @@ class ListHandler(logging.Handler):
 class ReusableTCPServer(socketserver.TCPServer):
     allow_reuse_address = True
 
-# Create handler for serving circuit graph data 
+
+# Create handler for serving circuit graph data
 # Local feature handling incorporated
 class CircuitGraphHandler(http.server.SimpleHTTPRequestHandler):
     def __init__(self, *args, frontend_dir, data_dir, features_dir, **kwargs):
@@ -56,34 +57,34 @@ class CircuitGraphHandler(http.server.SimpleHTTPRequestHandler):
     def _do_GET(self):
         logger.info(f"Received request for {self.path}")
 
-        if ((self.features_dir is not None) and (self.path.startswith('/features/'))):
-            rel_path = self.path[len('/features/'):].split('?')[0]
+        if (self.features_dir is not None) and (self.path.startswith("/features/")):
+            rel_path = self.path[len("/features/") :].split("?")[0]
             local_path = os.path.join(self.features_dir, rel_path)
             if not os.path.exists(local_path):
                 self.send_response(404)
                 self.end_headers()
                 return
-            range_header = self.headers.get('Range', '')
-            with open(local_path, 'rb') as f:
-                if range_header.startswith('bytes='):
+            range_header = self.headers.get("Range", "")
+            with open(local_path, "rb") as f:
+                if range_header.startswith("bytes="):
                     file_size = os.path.getsize(local_path)
-                    start, end = range_header[6:].split('-')
+                    start, end = range_header[6:].split("-")
                     start = int(start)
                     end = int(end) if end else file_size - 1
                     f.seek(start)
                     content = f.read(end - start + 1)
                     self.send_response(206)
-                    self.send_header('Content-Range', f'bytes {start}-{end}/{file_size}')
+                    self.send_header("Content-Range", f"bytes {start}-{end}/{file_size}")
                 else:
                     content = f.read()
                     self.send_response(200)
-            self.send_header('Content-Type', 'application/octet-stream')
-            self.send_header('Content-Length', str(len(content)))
-            self.send_header('Access-Control-Allow-Origin', '*')
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(content)))
+            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             self.wfile.write(content)
             return
-    
+
         # Handle data and graph_data requests from local storage
         if self.path.startswith(("/data/", "/graph_data/")):
             # Extract the file path from the URL
@@ -217,6 +218,7 @@ class Server:
         """Return the current log messages."""
         return self.logs
 
+
 def serve(data_dir, frontend_dir=None, features_dir=None, port=8032):
     """Start a local HTTP server in a separate thread.
 
@@ -240,7 +242,9 @@ def serve(data_dir, frontend_dir=None, features_dir=None, port=8032):
     logger.info(f"Serving files from: {frontend_dir}")
 
     # Create a partially applied handler class with configured directories
-    handler = functools.partial(CircuitGraphHandler, frontend_dir=frontend_dir, data_dir=data_dir, features_dir=features_dir)
+    handler = functools.partial(
+        CircuitGraphHandler, frontend_dir=frontend_dir, data_dir=data_dir, features_dir=features_dir
+    )
 
     httpd = ReusableTCPServer(("", port), handler)
 


### PR DESCRIPTION
**Summary:**
This PR adds support for fetching feature data from local CLTs in attribution graphs. Previously, no feature activation examples and histograms would show up for local (non-HuggingFace) CLTs; this was because init-feature-examples.js set all feature paths as HuggingFace paths and serve() / CircuitGraphHandler did not have any means for serving local features in addition to graphs, which prevented local examples and histograms from displaying. With this PR, feature examples and histograms show up correctly in attribution graphs for both local and HuggingFace-hosted CLTs.

**Changes:**
_circuit_tracer/frontend/assets/feature_examples/init-feature-examples.js_
Changed hfUrl() to featureUrl() and added compatibility to local CLTs by identifying non-HuggingFace CLT paths and setting feature path accordingly (rather than always setting feature path as a HuggingFace URL). Behavior is unchanged for HuggingFace CLT paths.
_circuit_tracer/frontend/local_server.py_
CircuitGraphHandler now accepts an optional features_dir argument to link a served attribution graph to local CLT features if needed. Behavior is unchanged if features_dir is not specified.

**Impact / Testing:**
Verified that local CLT directories with standard structure (features directory with index.json.gz and layer-wise binary files) now display feature activations and histograms in the attribution graph. Also verified that previously functional HuggingFace feature loading remains functional and works the same as before with no changes.

**Issue:**
Fixes the behavior described in [issue #91](https://github.com/decoderesearch/circuit-tracer/issues/91).