### PR TITLE
Stabilize row L1 graph normalization

### DIFF
--- a/circuit_tracer/graph.py
+++ b/circuit_tracer/graph.py
@@ -182,8 +182,83 @@ class Graph:
 
 
 def normalize_matrix(matrix: torch.Tensor) -> torch.Tensor:
-    normalized = matrix.abs()
-    return normalized / normalized.sum(dim=1, keepdim=True).clamp(min=1e-10)
+    return _normalize_abs_rows(matrix.abs(), clamp_min=1e-10)
+
+
+def _normalize_abs_rows(
+    abs_matrix: torch.Tensor, clamp_min: float, *, in_place: bool = False
+) -> torch.Tensor:
+    """Normalize non-negative rows by L1 norm without overflowing row sums.
+
+    This preserves ``abs_matrix / abs_matrix.sum(dim=1).clamp(min=clamp_min)``
+    for finite rows, but computes the denominator as ``row_abs_max * scaled_l1``
+    and divides in stages so large fp32 rows do not overflow to ``inf``. Set
+    ``in_place=True`` only when callers do not need gradients through
+    ``abs_matrix``.
+    """
+    if abs_matrix.ndim != 2:
+        raise ValueError("abs_matrix must be rank-2")
+    if not torch.is_floating_point(abs_matrix):
+        abs_matrix = abs_matrix.to(torch.get_default_dtype())
+
+    if abs_matrix.shape[1] == 0:
+        return abs_matrix
+
+    row_abs_max = abs_matrix.amax(dim=1, keepdim=True)
+    finite_nonzero_rows = ((row_abs_max > 0) & torch.isfinite(row_abs_max)).squeeze(1)
+    nan_rows = torch.isnan(row_abs_max)
+
+    if not in_place:
+        scale = torch.where(
+            finite_nonzero_rows.unsqueeze(1), row_abs_max, torch.ones_like(row_abs_max)
+        )
+        scaled_matrix = abs_matrix / scale
+
+        row_l1_scaled = scaled_matrix.sum(dim=1, keepdim=True)
+        scaled_threshold = torch.full_like(row_abs_max, clamp_min) / scale
+        use_scaled_l1 = finite_nonzero_rows.unsqueeze(1) & (row_l1_scaled >= scaled_threshold)
+
+        row_denominator = torch.where(
+            use_scaled_l1,
+            row_l1_scaled,
+            torch.where(finite_nonzero_rows.unsqueeze(1), scaled_threshold, row_l1_scaled),
+        )
+        row_denominator = row_denominator.clamp(min=clamp_min)
+        normalized = scaled_matrix / row_denominator
+        return torch.where(nan_rows, torch.full_like(normalized, float("nan")), normalized)
+
+    if bool(finite_nonzero_rows.any()):
+        scale = torch.where(
+            finite_nonzero_rows.unsqueeze(1), row_abs_max, torch.ones_like(row_abs_max)
+        )
+        abs_matrix.div_(scale)
+
+        row_l1_scaled = abs_matrix.sum(dim=1, keepdim=True)
+        scaled_threshold = torch.full_like(row_abs_max, clamp_min) / scale
+
+        row_denominator = torch.ones_like(row_abs_max)
+        use_scaled_l1 = finite_nonzero_rows & (row_l1_scaled >= scaled_threshold).squeeze(1)
+        use_clamp = finite_nonzero_rows & ~use_scaled_l1
+
+        if bool(use_scaled_l1.any()):
+            row_denominator[use_scaled_l1] = row_l1_scaled[use_scaled_l1]
+
+        if bool(use_clamp.any()):
+            row_denominator[use_clamp] = scaled_threshold[use_clamp]
+
+        abs_matrix.div_(row_denominator)
+
+    nonfinite_denominator_rows = (~torch.isfinite(row_abs_max)).squeeze(1)
+    if bool(nonfinite_denominator_rows.any()):
+        row_l1 = abs_matrix[nonfinite_denominator_rows].sum(dim=1, keepdim=True)
+        abs_matrix[nonfinite_denominator_rows] /= row_l1
+
+    if bool(nan_rows.any()):
+        abs_matrix[nan_rows.squeeze(1)] = torch.full_like(
+            abs_matrix[nan_rows.squeeze(1)], float("nan")
+        )
+
+    return abs_matrix
 
 
 def compute_influence(A: torch.Tensor, logit_weights: torch.Tensor, max_iter: int = 1000):
@@ -390,7 +465,7 @@ def compute_partial_influences(
 
     normalized_matrix = torch.empty_like(edge_matrix, device=device).copy_(edge_matrix)
     normalized_matrix = normalized_matrix.abs_()
-    normalized_matrix /= normalized_matrix.sum(dim=1, keepdim=True).clamp(min=1e-8)
+    normalized_matrix = _normalize_abs_rows(normalized_matrix, clamp_min=1e-8, in_place=True)
 
     influences = torch.zeros(edge_matrix.shape[1], device=normalized_matrix.device)
     prod = torch.zeros(edge_matrix.shape[1], device=normalized_matrix.device)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -6,7 +6,13 @@ import torch
 from transformer_lens import HookedTransformerConfig
 
 from circuit_tracer.attribution.targets import LogitTarget
-from circuit_tracer.graph import Graph, compute_edge_influence, compute_node_influence
+from circuit_tracer.graph import (
+    Graph,
+    compute_edge_influence,
+    compute_node_influence,
+    compute_partial_influences,
+    normalize_matrix,
+)
 from circuit_tracer.utils import get_default_device
 
 
@@ -15,6 +21,91 @@ def cleanup_cuda():
     yield
     torch.cuda.empty_cache()
     gc.collect()
+
+
+def test_normalize_matrix_avoids_float32_row_l1_overflow():
+    matrix = torch.full((1, 4), 1e38, dtype=torch.float32)
+
+    normalized = normalize_matrix(matrix)
+
+    assert torch.isfinite(normalized).all()
+    assert torch.allclose(normalized, torch.full_like(normalized, 0.25))
+
+
+def test_normalize_matrix_matches_safe_finite_rows():
+    matrix = torch.tensor([[3.0, -1.0, 0.0], [-2.0, 2.0, 4.0], [1e-20, 0.0, 0.0]])
+
+    normalized = normalize_matrix(matrix)
+
+    expected = matrix.abs() / matrix.abs().sum(dim=1, keepdim=True).clamp(min=1e-10)
+
+    assert torch.allclose(normalized, expected)
+
+
+def test_normalize_matrix_keeps_zero_rows_zero():
+    matrix = torch.zeros((2, 3), dtype=torch.float32)
+
+    normalized = normalize_matrix(matrix)
+
+    assert torch.equal(normalized, matrix)
+
+
+def test_normalize_matrix_infinite_rows_match_existing_nonfinite_behavior():
+    matrix = torch.tensor([[float("inf"), 1.0]], dtype=torch.float32)
+
+    normalized = normalize_matrix(matrix)
+
+    assert torch.isnan(normalized[0, 0])
+    assert normalized[0, 1] == 0
+
+
+def test_normalize_matrix_nan_rows_propagate_nan():
+    matrix = torch.tensor([[float("nan"), 1.0]], dtype=torch.float32)
+
+    normalized = normalize_matrix(matrix)
+
+    assert torch.isnan(normalized).all()
+
+
+def test_normalize_matrix_integer_inputs_return_float_values():
+    matrix = torch.tensor([[1, 3]], dtype=torch.int64)
+
+    normalized = normalize_matrix(matrix)
+
+    assert torch.is_floating_point(normalized)
+    assert torch.allclose(normalized, torch.tensor([[0.25, 0.75]]))
+
+
+def test_normalize_matrix_preserves_autograd():
+    matrix = torch.tensor([[1.0, 3.0]], requires_grad=True)
+
+    normalized = normalize_matrix(matrix)
+    normalized.sum().backward()
+
+    assert matrix.grad is not None
+
+
+@pytest.mark.parametrize("row", [[[0.0, 0.0]], [[1e-20, 0.0]]])
+def test_normalize_matrix_clamped_rows_have_finite_gradients(row):
+    matrix = torch.tensor(row, requires_grad=True)
+
+    normalized = normalize_matrix(matrix)
+    normalized.sum().backward()
+
+    assert matrix.grad is not None
+    assert torch.isfinite(matrix.grad).all()
+
+
+def test_compute_partial_influences_avoids_float32_row_l1_overflow():
+    edge_matrix = torch.tensor([[1e38, 1e38, 0.0]], dtype=torch.float32)
+    logit_p = torch.tensor([1.0], dtype=torch.float32)
+    row_to_node_index = torch.tensor([2], dtype=torch.int32)
+
+    influences = compute_partial_influences(edge_matrix, logit_p, row_to_node_index)
+
+    expected = torch.tensor([0.5, 0.5, 0.0], device=influences.device)
+    assert torch.isfinite(influences).all()
+    assert torch.allclose(influences, expected)
 
 
 def test_small_graph():


### PR DESCRIPTION
## Summary
This PR makes graph row normalization robust to fp32 row-L1 overflow.
Previously, graph normalization used raw row sums like:
`matrix.abs().sum(dim=1, keepdim=True)`
For large finite fp32 rows, that sum can overflow to inf, causing normalized rows to collapse toward zero. This affects both graph normalization and partial influence ranking.
This change:
- adds a shared private row-normalization helper that scales each row by its max absolute value before computing the row L1 denominator
- routes both `normalize_matrix()` and `compute_partial_influences()` through the helper
- keeps `normalize_matrix()` out-of-place/autograd-compatible
- keeps the `compute_partial_influences()` path in-place after its existing copy to avoid unnecessary peak memory growth
- preserves existing behavior for safe finite rows, zero rows, tiny clamped rows, integer inputs, and explicit nonfinite rows

## Motivation
This came up while tracing Gemma 3 1B with Gemma Scope 2 CLTs on GSM8K-style prompts, where some prompts produced millions of active features before graph pruning/ranking. In that setting, fp32 row-L1 sums could overflow for some attribution rows, collapsing otherwise finite normalized rows.
In one feature-distribution sweep, several prompts had more than 4M active features before pruning/ranking, with the largest observed prompt around 7.9M active features.
The tests in this PR use synthetic tensors rather than model-specific traces, so the regression is covered without requiring a particular model, dataset, or large trace.

## Tests
Run:
`python -m ruff check circuit_tracer/graph.py tests/test_graph.py`
`python -m ruff format --check circuit_tracer/graph.py tests/test_graph.py`
`python -m pytest tests/test_graph.py`
`python -m pytest tests/test_graph.py tests/transcoder/test_activation_functions.py tests/transcoder/test_single_layer_transcoder.py tests/transcoder/test_cross_layer_transcoder.py tests/utils/test_hf_utils.py tests/utils/test_disk_offload.py -m "not requires_disk"`

## Results:
ruff check: passed
ruff format --check: passed
tests/test_graph.py: 15 passed
lightweight subset: 42 passed, 2 skipped, 9 deselected

## Notes
The new tests cover:
- fp32 overflow rows such as [[1e38, 1e38, 1e38, 1e38]]
- safe finite signed rows
- tiny clamped rows
- zero rows
- explicit inf and nan rows
- integer input behavior
- autograd through normalize_matrix()
- compute_partial_influences() overflow behavior