### PR TITLE
fix: resolve node_id collision between error nodes and CLT feature nodes

### DIFF
--- a/circuit_tracer/frontend/graph_models.py
+++ b/circuit_tracer/frontend/graph_models.py
@@ -63,7 +63,7 @@ class Node(BaseModel):
         """Create an error node."""
         reverse_ctx_idx = 0
         return cls(
-            node_id=f"0_{layer}_{pos}",
+            node_id=f"{layer}_-1_{pos}",
             feature=-1,
             layer=str(layer),
             ctx_idx=pos,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -6,6 +6,7 @@ import torch
 from transformer_lens import HookedTransformerConfig
 
 from circuit_tracer.attribution.targets import LogitTarget
+from circuit_tracer.frontend.graph_models import Node
 from circuit_tracer.graph import Graph, compute_edge_influence, compute_node_influence
 from circuit_tracer.utils import get_default_device
 
@@ -356,3 +357,22 @@ def test_graph_from_pt_legacy_tensor_format():
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
+
+
+def test_error_node_id_format_no_collision():
+    """Error node IDs must use {layer}_-1_{pos}, not 0_{layer}_{pos}.
+
+    The old format caused real collisions: error(layer=0, pos=1) → "0_0_1"
+    matches feature(layer=0, feat_idx=0, pos=1) → "0_0_1".
+    """
+    error = Node.error_node(layer=0, pos=1)
+    feature = Node.feature_node(layer=0, pos=1, feat_idx=0)
+
+    assert error.node_id != feature.node_id, "error node and CLT feature node share a node_id"
+    assert error.node_id == "0_-1_1", f"unexpected error node_id format: {error.node_id!r}"
+    assert feature.node_id == "0_0_1", f"unexpected feature node_id format: {feature.node_id!r}"
+
+    for layer in range(3):
+        for pos in range(2):
+            e = Node.error_node(layer=layer, pos=pos)
+            assert e.node_id == f"{layer}_-1_{pos}"


### PR DESCRIPTION
Fixes #78

Error nodes were assigned IDs using the format `0_{layer}_{pos}`, which collides with CLT feature nodes at layer 0 whose feature index happens to equal the error node's layer. For example:

- `error(layer=0, pos=1)` → `"0_0_1"`
- `feature(layer=0, feat_idx=0, pos=1)` → `"0_0_1"`

More generally, `error(layer=L, pos=P)` collides with any `feature(layer=0, feat_idx=L, pos=P)`.

## Fix

Change `error_node()` to use `{layer}_-1_{pos}`, consistent with the CLT format `{layer}_{feat_idx}_{pos}` and the already-set `feature=-1` sentinel.

## Changes

- `circuit_tracer/frontend/graph_models.py`: fix `error_node()` node_id format
- `tests/test_graph.py`: add test asserting error and CLT node IDs are distinct and follow the expected format

## Note

This is a breaking change for persisted graph URLs or browser localStorage pinning error node IDs generated before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)