### PR TITLE
feat: add --device CLI flag for MPS and CPU override

### DIFF
--- a/circuit_tracer/__main__.py
+++ b/circuit_tracer/__main__.py
@@ -96,6 +96,12 @@ def main():
         default="transformerlens",
         help="Backend to use for the replacement model (default: transformerlens).",
     )
+    attr_parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Device to run on (e.g. cuda, mps, cpu). Defaults to cuda if available, then mps, then cpu.",
+    )
 
     # Arguments for graph creation
     attr_parser.add_argument(
@@ -211,9 +217,21 @@ def run_attribution(args, parser):
         dtype = dtype_mapping[dtype]
     dtype = getattr(torch, dtype)
 
+    # Resolve device
+    from circuit_tracer.utils import get_default_device
+
+    if args.device is not None:
+        try:
+            device = torch.device(args.device)
+        except RuntimeError as e:
+            parser.error(f"Invalid --device value {args.device!r}: {e}")
+    else:
+        device = get_default_device()
+
     # Run attribution
     logging.info(f"Generating attribution graph for model: {args.model}")
     logging.info(f"Loading model with dtype: {dtype}")
+    logging.info(f"Using device: {device}")
     logging.info(f'Input prompt: "{args.prompt}"')
     if args.graph_output_path:
         logging.info(f"Output will be saved to: {args.graph_output_path}")
@@ -230,6 +248,7 @@ def run_attribution(args, parser):
     transcoder, config = load_transcoder_from_hub(
         args.transcoder_set,
         dtype=dtype,
+        device=device,
         lazy_encoder=args.lazy_encoder,
         lazy_decoder=args.lazy_decoder,
     )
@@ -238,7 +257,7 @@ def run_attribution(args, parser):
         parser.error("--model must be specified when not provided in transcoder config")
 
     model_instance = ReplacementModel.from_pretrained_and_transcoders(
-        args.model, transcoder, dtype=dtype, backend=args.backend
+        args.model, transcoder, dtype=dtype, device=device, backend=args.backend
     )
 
     logging.info("Running attribution...")

--- a/circuit_tracer/utils/__init__.py
+++ b/circuit_tracer/utils/__init__.py
@@ -3,8 +3,12 @@ from circuit_tracer.utils.create_graph_files import create_graph_files as create
 
 
 def get_default_device() -> torch.device:
-    """Get the default device, preferring CUDA if available."""
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    """Get the default device, preferring CUDA, then MPS, then CPU."""
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
 
 
 __all__ = ["create_graph_files", "get_default_device"]


### PR DESCRIPTION
Fixes #1

The `attribute` subcommand defaulted to CUDA with no way to override, making MPS (Apple Silicon) and CPU-only runs impossible from the CLI.

## Changes

**`circuit_tracer/__main__.py`**
- Add `--device` argument to the `attribute` subparser (e.g. `--device mps`, `--device cpu`, `--device cuda`)
- Validate the value with `torch.device()` and raise a clean `ArgumentTypeError` rather than letting PyTorch's `RuntimeError` escape to the user
- Pass the resolved device to both `load_transcoder_from_hub()` and `ReplacementModel.from_pretrained_and_transcoders()` so all weights land on the same device consistently (addresses the gap Codex identified — transcoder weights must go to the same device as the model)
- Log the chosen device at startup

**`circuit_tracer/utils/__init__.py`**
- Update `get_default_device()` to prefer `cuda → mps → cpu`, so Apple Silicon users get MPS automatically without needing to pass the flag

## Usage

```bash
# Apple Silicon
circuit-tracer attribute --device mps --transcoder_set ... --prompt "..."

# Force CPU (useful for debugging)
circuit-tracer attribute --device cpu --transcoder_set ... --prompt "..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)