### PR TITLE
Don't raise in ReplacementModel.__del__ (guard teardown cleanup)

### DIFF
--- a/circuit_tracer/replacement_model/replacement_model_transformerlens.py
+++ b/circuit_tracer/replacement_model/replacement_model_transformerlens.py
@@ -928,5 +928,12 @@ class TransformerLensReplacementModel(HookedTransformer):
         return generation, logits.squeeze(0), activations
 
     def __del__(self):
-        # Prevent memory leaks
-        self.reset_hooks(including_permanent=True)
+        # Prevent memory leaks. Guard against errors during interpreter teardown:
+        # at shutdown, torch type objects may be partially collected, so
+        # reset_hooks() can raise (e.g. "TypeError: isinstance() arg 2 must be a
+        # type ..." from torch.nn.Parameter.__instancecheck__), surfacing as a noisy
+        # "Exception ignored in __del__". Destructors must not raise.
+        try:
+            self.reset_hooks(including_permanent=True)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

After an attribution graph is built and saved, `TransformerLensReplacementModel.__del__` can raise during interpreter teardown:

```
Exception ignored in: <function TransformerLensReplacementModel.__del__ ...>
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
  ... reset_hooks -> clear_contexts -> clear_context
  ... torch/nn/parameter.py ... Parameter.__instancecheck__
```

It is harmless (the graph is already saved) but noisy and looks like a failure. At shutdown, torch type objects can be partially collected, so the `isinstance(..., torch.nn.Parameter)` inside TransformerLens's hook cleanup raises. A destructor should never raise.

## Fix

Wrap the `reset_hooks(...)` call in `__del__` in `try/except`. No behavior change in normal operation; it only suppresses errors that occur while the interpreter is tearing down.

## Verification

- **Before:** two full Gemma-2-2B attribution runs emitted the `TypeError` at exit.
- **After:** a minimal load → exit test emits **0** `TypeError` and **0** "Exception ignored in __del__" lines.

Context: found while running `circuit-tracer` CPU-only on Gemma-2-2B + GemmaScope, which works well (forward ~17 s + attribution ~68 s on a 24-thread CPU, `offload=None`).
