### PR TITLE
nit: bump version to 0.5.2 in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "circuit-tracer"
-version = "0.4.1"
+version = "0.5.1"
 description = "Library for circuit tracing in language models"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Not super important, but we use the version number in some places (eg showing the user what version circuit tracer was used to generate). I changed it to 0.5.2 because if this is deployed then the new tag would be updated? Or maybe we overwrite 0.5.1 tag. I'm fine with either solution!

Also I wonder if there should be an automated way to update this