### PR TITLE
Add long-context memory estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ We also make two simple demos of attribution and intervention available, for tho
 - [`demos/attribute_demo.ipynb`](https://github.com/safety-research/circuit-tracer/blob/main/demos/attribute_demo.ipynb): Demonstrates how to find circuits and visualize them. 
 - [`demos/attribution_targets_demo.ipynb`](https://github.com/safety-research/circuit-tracer/blob/main/demos/attribution_targets_demo.ipynb): Demonstrates how to find circuits by specifying attribution targets, i.e. specific logits (or related quantities) that you wish to attribute from. 
 - [`demos/intervention_demo.ipynb`](https://github.com/safety-research/circuit-tracer/blob/main/demos/intervention_demo.ipynb): Demonstrates how to perform interventions on models. 
+- [`demos/long_context_memory_estimator_demo.ipynb`](demos/long_context_memory_estimator_demo.ipynb): Demonstrates how to estimate dense graph memory before running long-context attribution.
 
 We finally provide demos that dig deeper into specific, pre-computed and pre-annotated attribution graphs, performing interventions to demonstrate the correctness of the annotated graph:
 - [`demos/gemma_demo.ipynb`](https://github.com/safety-research/circuit-tracer/blob/main/demos/gemma_demo.ipynb): Explores graphs from Gemma 2 (2B).
@@ -153,6 +154,22 @@ circuit-tracer attribute \
   --transcoder_set llama \
   --graph_output_path france_capital.pt
 ```
+
+**Estimate dense graph memory before a long-context trace:**
+```
+circuit-tracer estimate-memory \
+  --tokens 6000 \
+  --layers 26 \
+  --max_feature_nodes 7500 \
+  --n_logits 10 \
+  --dtype float16 \
+  --available_memory_gib 80
+```
+
+This command does not load a model or transcoders. It estimates the dense adjacency matrix,
+graph-pruning intermediates, and graph metadata tensors so you can catch likely OOM cases before
+starting an expensive attribution run. For details and rationale, see
+[`docs/long_context_memory_estimator.md`](docs/long_context_memory_estimator.md).
 
 ### Graph Annotation
 When using the `--server` option, your browser will open to a local visualization interface. The interface is the same as in [the original papers](https://transformer-circuits.pub/2025/attribution-graphs/methods.html) (frontend available [here](https://github.com/anthropics/attribution-graphs-frontend)).

--- a/circuit_tracer/__main__.py
+++ b/circuit_tracer/__main__.py
@@ -159,12 +159,69 @@ def main():
     )
     server_parser.add_argument("--port", type=int, default=8041, help="Port for the local server.")
 
+    # Estimate-memory subcommand
+    estimate_parser = subparsers.add_parser(
+        "estimate-memory",
+        help="Estimate dense attribution-graph memory before running a trace",
+    )
+    estimate_parser.add_argument(
+        "--tokens",
+        type=int,
+        required=True,
+        help="Prompt length after tokenization.",
+    )
+    estimate_parser.add_argument(
+        "--layers",
+        type=int,
+        required=True,
+        help="Number of transformer layers in the model.",
+    )
+    estimate_parser.add_argument(
+        "--max_feature_nodes",
+        type=int,
+        default=7500,
+        help="Maximum number of feature nodes retained during attribution.",
+    )
+    estimate_parser.add_argument(
+        "--n_logits",
+        type=int,
+        default=10,
+        help="Number of logit target nodes.",
+    )
+    estimate_parser.add_argument(
+        "--dtype",
+        type=str,
+        choices=["float64", "fp64", "float32", "fp32", "bfloat16", "bf16", "float16", "fp16"],
+        default="float32",
+        help="Floating point dtype for dense graph tensors.",
+    )
+    estimate_parser.add_argument(
+        "--available_memory_gib",
+        type=float,
+        default=None,
+        help="Optional device memory budget in GiB.",
+    )
+    estimate_parser.add_argument(
+        "--safety_fraction",
+        type=float,
+        default=0.8,
+        help="Fraction of available memory treated as usable.",
+    )
+    estimate_parser.add_argument(
+        "--format",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Output format.",
+    )
+
     args = parser.parse_args()
 
     if args.command == "attribute":
         run_attribution(args, attr_parser)
-    if args.command == "start-server" or args.server:
+    elif args.command == "start-server" or getattr(args, "server", False):
         run_server(args)
+    elif args.command == "estimate-memory":
+        run_estimate_memory(args)
 
 
 def run_attribution(args, parser):
@@ -290,6 +347,25 @@ def run_server(args):
     except KeyboardInterrupt:
         logging.info("Stopping server...")
         server.stop()
+
+
+def run_estimate_memory(args):
+    from circuit_tracer.utils.memory_estimation import estimate_graph_memory
+
+    estimate = estimate_graph_memory(
+        n_tokens=args.tokens,
+        n_layers=args.layers,
+        max_feature_nodes=args.max_feature_nodes,
+        n_logits=args.n_logits,
+        dtype=args.dtype,
+        available_memory_gib=args.available_memory_gib,
+        safety_fraction=args.safety_fraction,
+    )
+
+    if args.format == "json":
+        print(estimate.to_json())
+    else:
+        print(estimate.to_markdown())
 
 
 if __name__ == "__main__":

--- a/circuit_tracer/utils/__init__.py
+++ b/circuit_tracer/utils/__init__.py
@@ -1,5 +1,6 @@
 import torch
 from circuit_tracer.utils.create_graph_files import create_graph_files as create_graph_files
+from circuit_tracer.utils.memory_estimation import estimate_graph_memory as estimate_graph_memory
 
 
 def get_default_device() -> torch.device:
@@ -7,4 +8,4 @@ def get_default_device() -> torch.device:
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-__all__ = ["create_graph_files", "get_default_device"]
+__all__ = ["create_graph_files", "estimate_graph_memory", "get_default_device"]

--- a/circuit_tracer/utils/memory_estimation.py
+++ b/circuit_tracer/utils/memory_estimation.py
@@ -1,0 +1,347 @@
+"""Memory estimates for attribution graph construction.
+
+The attribution pipeline currently materializes dense ``N x N`` tensors for the
+graph adjacency and for graph-pruning intermediates.  This module gives users a
+cheap way to estimate that footprint before launching a long-context trace.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from typing import Any
+
+
+DTYPE_BYTES = {
+    "float64": 8,
+    "fp64": 8,
+    "float32": 4,
+    "fp32": 4,
+    "bfloat16": 2,
+    "bf16": 2,
+    "float16": 2,
+    "fp16": 2,
+}
+
+CANONICAL_DTYPE = {
+    "fp64": "float64",
+    "fp32": "float32",
+    "bf16": "bfloat16",
+    "fp16": "float16",
+}
+
+
+def normalize_dtype_name(dtype: str) -> str:
+    """Return the canonical dtype name supported by the estimator."""
+    normalized = dtype.lower()
+    if normalized not in DTYPE_BYTES:
+        supported = ", ".join(sorted(DTYPE_BYTES))
+        raise ValueError(f"Unsupported dtype {dtype!r}. Supported dtypes: {supported}")
+    return CANONICAL_DTYPE.get(normalized, normalized)
+
+
+def format_bytes(num_bytes: int) -> str:
+    """Format a byte count using binary units."""
+    if num_bytes < 0:
+        raise ValueError("num_bytes must be non-negative")
+    if num_bytes == 0:
+        return "0 B"
+
+    units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
+    unit_index = min(int(math.log(num_bytes, 1024)), len(units) - 1)
+    value = num_bytes / (1024**unit_index)
+    return f"{value:.2f} {units[unit_index]}"
+
+
+@dataclass(frozen=True)
+class GraphMemoryEstimate:
+    """Estimated dense memory use for one attribution graph."""
+
+    n_tokens: int
+    n_layers: int
+    max_feature_nodes: int
+    n_logits: int
+    dtype: str
+    bytes_per_value: int
+    n_feature_nodes: int
+    n_error_nodes: int
+    n_token_nodes: int
+    n_logit_nodes: int
+    n_total_nodes: int
+    dense_adjacency_bytes: int
+    dense_bool_mask_bytes: int
+    graph_metadata_bytes: int
+    pruning_peak_bytes: int
+    estimated_peak_bytes: int
+    available_memory_bytes: int | None
+    usable_memory_bytes: int | None
+    fits_usable_memory: bool | None
+    recommendations: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "inputs": {
+                "n_tokens": self.n_tokens,
+                "n_layers": self.n_layers,
+                "max_feature_nodes": self.max_feature_nodes,
+                "n_logits": self.n_logits,
+                "dtype": self.dtype,
+                "bytes_per_value": self.bytes_per_value,
+                "available_memory": (
+                    format_bytes(self.available_memory_bytes)
+                    if self.available_memory_bytes is not None
+                    else None
+                ),
+                "usable_memory": (
+                    format_bytes(self.usable_memory_bytes)
+                    if self.usable_memory_bytes is not None
+                    else None
+                ),
+            },
+            "nodes": {
+                "feature_nodes": self.n_feature_nodes,
+                "error_nodes": self.n_error_nodes,
+                "token_nodes": self.n_token_nodes,
+                "logit_nodes": self.n_logit_nodes,
+                "total_nodes": self.n_total_nodes,
+            },
+            "memory": {
+                "dense_adjacency": format_bytes(self.dense_adjacency_bytes),
+                "dense_bool_mask": format_bytes(self.dense_bool_mask_bytes),
+                "graph_metadata": format_bytes(self.graph_metadata_bytes),
+                "pruning_peak": format_bytes(self.pruning_peak_bytes),
+                "estimated_peak": format_bytes(self.estimated_peak_bytes),
+                "dense_adjacency_bytes": self.dense_adjacency_bytes,
+                "pruning_peak_bytes": self.pruning_peak_bytes,
+                "estimated_peak_bytes": self.estimated_peak_bytes,
+            },
+            "fits_usable_memory": self.fits_usable_memory,
+            "recommendations": list(self.recommendations),
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# circuit-tracer memory estimate",
+            "",
+            "## Inputs",
+            "",
+            f"- Tokens: {self.n_tokens:,}",
+            f"- Layers: {self.n_layers:,}",
+            f"- Max feature nodes: {self.max_feature_nodes:,}",
+            f"- Logit nodes: {self.n_logits:,}",
+            f"- Dtype: {self.dtype} ({self.bytes_per_value} bytes/value)",
+        ]
+        if self.available_memory_bytes is not None:
+            lines.extend(
+                [
+                    f"- Available memory: {format_bytes(self.available_memory_bytes)}",
+                    f"- Usable memory after safety margin: {format_bytes(self.usable_memory_bytes or 0)}",
+                ]
+            )
+
+        lines.extend(
+            [
+                "",
+                "## Estimated graph size",
+                "",
+                f"- Feature nodes: {self.n_feature_nodes:,}",
+                f"- Error nodes: {self.n_error_nodes:,}",
+                f"- Token nodes: {self.n_token_nodes:,}",
+                f"- Logit nodes: {self.n_logit_nodes:,}",
+                f"- Total nodes: {self.n_total_nodes:,}",
+                "",
+                "## Estimated dense memory",
+                "",
+                f"- Dense adjacency tensor: {format_bytes(self.dense_adjacency_bytes)}",
+                f"- Dense boolean mask: {format_bytes(self.dense_bool_mask_bytes)}",
+                f"- Feature/token metadata tensors: {format_bytes(self.graph_metadata_bytes)}",
+                f"- Estimated graph-pruning peak: {format_bytes(self.pruning_peak_bytes)}",
+                f"- Estimated end-to-end peak: {format_bytes(self.estimated_peak_bytes)}",
+            ]
+        )
+
+        if self.fits_usable_memory is not None:
+            fit_text = "yes" if self.fits_usable_memory else "no"
+            lines.extend(["", f"Fits usable memory: **{fit_text}**"])
+
+        if self.recommendations:
+            lines.extend(["", "## Recommendations", ""])
+            lines.extend(f"- {recommendation}" for recommendation in self.recommendations)
+
+        return "\n".join(lines)
+
+
+def estimate_graph_memory(
+    *,
+    n_tokens: int,
+    n_layers: int,
+    max_feature_nodes: int = 7500,
+    n_logits: int = 10,
+    dtype: str = "float32",
+    available_memory_gib: float | None = None,
+    safety_fraction: float = 0.8,
+) -> GraphMemoryEstimate:
+    """Estimate dense attribution graph memory for a prompt.
+
+    Args:
+        n_tokens: Prompt length after tokenization.
+        n_layers: Number of transformer layers. Each layer contributes one
+            reconstruction-error node per token.
+        max_feature_nodes: Upper bound used by ``attribute(..., max_feature_nodes=...)``.
+        n_logits: Number of output logit target nodes.
+        dtype: Floating point dtype used for dense graph tensors.
+        available_memory_gib: Optional device memory budget to compare against.
+        safety_fraction: Fraction of available memory treated as usable.
+
+    Returns:
+        A ``GraphMemoryEstimate`` with formatted and raw byte counts.
+    """
+    if n_tokens <= 0:
+        raise ValueError("n_tokens must be positive")
+    if n_layers <= 0:
+        raise ValueError("n_layers must be positive")
+    if max_feature_nodes < 0:
+        raise ValueError("max_feature_nodes must be non-negative")
+    if n_logits <= 0:
+        raise ValueError("n_logits must be positive")
+    if not 0 < safety_fraction <= 1:
+        raise ValueError("safety_fraction must be in (0, 1]")
+
+    dtype = normalize_dtype_name(dtype)
+    bytes_per_value = DTYPE_BYTES[dtype]
+
+    n_feature_nodes = max_feature_nodes
+    n_error_nodes = n_layers * n_tokens
+    n_token_nodes = n_tokens
+    n_logit_nodes = n_logits
+    n_total_nodes = n_feature_nodes + n_error_nodes + n_token_nodes + n_logit_nodes
+
+    dense_matrix_entries = n_total_nodes * n_total_nodes
+    dense_adjacency_bytes = dense_matrix_entries * bytes_per_value
+    dense_bool_mask_bytes = dense_matrix_entries
+
+    # Small graph-side tensors that scale linearly with node count.  This is not
+    # the full model/transcoder footprint; it captures graph metadata only.
+    graph_metadata_bytes = (
+        n_feature_nodes * 3 * 8  # active feature layer/position/index
+        + n_feature_nodes * 8  # selected feature indices
+        + n_feature_nodes * bytes_per_value  # activation values
+        + n_token_nodes * 8
+        + n_logit_nodes * (8 + bytes_per_value)
+    )
+
+    # prune_graph currently has the original adjacency, a pruned clone, a
+    # normalized pruned matrix, edge scores, and a dense bool mask live near the
+    # edge-pruning step. This is intentionally approximate and conservative.
+    pruning_peak_bytes = 4 * dense_adjacency_bytes + dense_bool_mask_bytes
+    estimated_peak_bytes = pruning_peak_bytes + graph_metadata_bytes
+
+    available_memory_bytes = None
+    usable_memory_bytes = None
+    fits_usable_memory = None
+    if available_memory_gib is not None:
+        if available_memory_gib <= 0:
+            raise ValueError("available_memory_gib must be positive when provided")
+        available_memory_bytes = int(available_memory_gib * 1024**3)
+        usable_memory_bytes = int(available_memory_bytes * safety_fraction)
+        fits_usable_memory = estimated_peak_bytes <= usable_memory_bytes
+
+    recommendations = _build_recommendations(
+        n_tokens=n_tokens,
+        n_total_nodes=n_total_nodes,
+        dense_adjacency_bytes=dense_adjacency_bytes,
+        estimated_peak_bytes=estimated_peak_bytes,
+        usable_memory_bytes=usable_memory_bytes,
+        fits_usable_memory=fits_usable_memory,
+        dtype=dtype,
+        max_feature_nodes=max_feature_nodes,
+    )
+
+    return GraphMemoryEstimate(
+        n_tokens=n_tokens,
+        n_layers=n_layers,
+        max_feature_nodes=max_feature_nodes,
+        n_logits=n_logits,
+        dtype=dtype,
+        bytes_per_value=bytes_per_value,
+        n_feature_nodes=n_feature_nodes,
+        n_error_nodes=n_error_nodes,
+        n_token_nodes=n_token_nodes,
+        n_logit_nodes=n_logit_nodes,
+        n_total_nodes=n_total_nodes,
+        dense_adjacency_bytes=dense_adjacency_bytes,
+        dense_bool_mask_bytes=dense_bool_mask_bytes,
+        graph_metadata_bytes=graph_metadata_bytes,
+        pruning_peak_bytes=pruning_peak_bytes,
+        estimated_peak_bytes=estimated_peak_bytes,
+        available_memory_bytes=available_memory_bytes,
+        usable_memory_bytes=usable_memory_bytes,
+        fits_usable_memory=fits_usable_memory,
+        recommendations=tuple(recommendations),
+    )
+
+
+def _build_recommendations(
+    *,
+    n_tokens: int,
+    n_total_nodes: int,
+    dense_adjacency_bytes: int,
+    estimated_peak_bytes: int,
+    usable_memory_bytes: int | None,
+    fits_usable_memory: bool | None,
+    dtype: str,
+    max_feature_nodes: int,
+) -> list[str]:
+    recommendations: list[str] = []
+
+    if fits_usable_memory is False:
+        assert usable_memory_bytes is not None
+        shortfall = estimated_peak_bytes / max(usable_memory_bytes, 1)
+        recommendations.append(
+            "Estimated pruning peak exceeds the usable memory budget "
+            f"by {shortfall:.1f}x; reduce prompt length, layers, logits, or feature cap."
+        )
+    elif usable_memory_bytes is not None and estimated_peak_bytes > usable_memory_bytes * 0.7:
+        recommendations.append(
+            "Estimate is within memory budget but close enough that allocator overhead, "
+            "model weights, and transcoders can still trigger OOM."
+        )
+
+    if dtype == "float32":
+        recommendations.append(
+            "Try --dtype bfloat16 or --dtype float16 when numerically acceptable; dense graph "
+            "memory is roughly halved."
+        )
+
+    if n_tokens >= 4096:
+        recommendations.append(
+            "Long prompts create one reconstruction-error node per layer per token; this is "
+            "usually the dominant node-count driver."
+        )
+
+    if max_feature_nodes >= 7500:
+        recommendations.append(
+            "Lower --max_feature_nodes for exploratory traces; pruning thresholds do not reduce "
+            "the initial dense graph allocation."
+        )
+
+    if dense_adjacency_bytes > 16 * 1024**3:
+        recommendations.append(
+            "Dense adjacency alone is large. A sparse or blockwise graph backend is the right "
+            "next engineering target for this configuration."
+        )
+
+    if n_total_nodes > 50_000:
+        recommendations.append(
+            "Graph has more than 50k nodes before pruning; local visualization JSON may also "
+            "become large even if attribution succeeds."
+        )
+
+    if not recommendations:
+        recommendations.append("No immediate dense-graph memory risk flagged by this estimate.")
+
+    return recommendations

--- a/demos/long_context_memory_estimator_demo.ipynb
+++ b/demos/long_context_memory_estimator_demo.ipynb
@@ -1,0 +1,267 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Tutorial: Long-context memory estimator\n",
+        "\n",
+        "Audience:\n",
+        "- `circuit-tracer` users planning attribution runs on long prompts.\n",
+        "- Contributors evaluating why a trace may run out of memory before graph export.\n",
+        "\n",
+        "Prerequisites:\n",
+        "- Basic familiarity with attribution graphs and transformer layer/token counts.\n",
+        "- A local checkout or installed copy of `circuit-tracer` from this branch.\n",
+        "\n",
+        "Learning goals:\n",
+        "- Estimate dense graph memory without loading a model or transcoders.\n",
+        "- Understand why long contexts create many reconstruction-error nodes.\n",
+        "- Compare dtype and feature-node cap tradeoffs before launching a trace.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Outline\n",
+        "\n",
+        "1. Import the estimator from a local checkout.\n",
+        "2. Estimate a small prompt that should fit comfortably.\n",
+        "3. Estimate a long-context prompt that is likely to fail with dense graph tensors.\n",
+        "4. Compare dtype and feature-node cap choices.\n",
+        "5. Use the CLI equivalent.\n",
+        "6. Exercise: adjust the configuration and inspect the result.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Make the notebook work both from the repository root and from demos/.\n",
+        "from __future__ import annotations\n",
+        "\n",
+        "from pathlib import Path\n",
+        "import sys\n",
+        "\n",
+        "repo_root = Path.cwd()\n",
+        "if repo_root.name == \"demos\":\n",
+        "    repo_root = repo_root.parent\n",
+        "if str(repo_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(repo_root))\n",
+        "\n",
+        "from circuit_tracer.utils.memory_estimation import estimate_graph_memory, format_bytes\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 - A small prompt estimate\n",
+        "\n",
+        "The graph has feature nodes, error nodes, token nodes, and logit nodes. Error nodes scale as `layers * tokens`, so even a modest prompt grows with model depth.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "small = estimate_graph_memory(\n",
+        "    n_tokens=128,\n",
+        "    n_layers=26,\n",
+        "    max_feature_nodes=7500,\n",
+        "    n_logits=10,\n",
+        "    dtype=\"float16\",\n",
+        "    available_memory_gib=24,\n",
+        ")\n",
+        "\n",
+        "print(small.to_markdown())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Interpretation: for this configuration, the dense graph tensors are large but usually not the dominant concern on a 24 GiB GPU. The model and transcoder weights still need memory, so this estimate is a lower-level graph preflight rather than a full runtime guarantee.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 - A long-context estimate\n",
+        "\n",
+        "Now estimate a 6,000-token prompt on a 26-layer model. This mirrors the class of OOM reports where the graph representation itself becomes the bottleneck.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "long_context = estimate_graph_memory(\n",
+        "    n_tokens=6000,\n",
+        "    n_layers=26,\n",
+        "    max_feature_nodes=7500,\n",
+        "    n_logits=10,\n",
+        "    dtype=\"float16\",\n",
+        "    available_memory_gib=80,\n",
+        ")\n",
+        "\n",
+        "summary = long_context.to_dict()\n",
+        "print(\"total nodes:\", f\"{summary['nodes']['total_nodes']:,}\")\n",
+        "print(\"dense adjacency:\", summary[\"memory\"][\"dense_adjacency\"])\n",
+        "print(\"estimated peak:\", summary[\"memory\"][\"estimated_peak\"])\n",
+        "print(\"fits usable memory:\", summary[\"fits_usable_memory\"])\n",
+        "print(\"first recommendation:\", summary[\"recommendations\"][0])\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Interpretation: even with `float16`, dense adjacency and pruning intermediates can exceed an 80 GiB device budget after a safety margin. This is why shortening the prompt, lowering feature caps, or implementing a sparse/blockwise backend matters.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 - Compare dtype choices\n",
+        "\n",
+        "Dense graph memory scales linearly with bytes per value. Switching from `float32` to `float16` or `bfloat16` roughly halves the dense floating-point tensor footprint.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for dtype in [\"float32\", \"bfloat16\", \"float16\"]:\n",
+        "    estimate = estimate_graph_memory(\n",
+        "        n_tokens=2048,\n",
+        "        n_layers=26,\n",
+        "        max_feature_nodes=7500,\n",
+        "        n_logits=10,\n",
+        "        dtype=dtype,\n",
+        "        available_memory_gib=80,\n",
+        "    )\n",
+        "    print(\n",
+        "        f\"{dtype:8s}\",\n",
+        "        \"nodes=\", f\"{estimate.n_total_nodes:,}\",\n",
+        "        \"adjacency=\", format_bytes(estimate.dense_adjacency_bytes),\n",
+        "        \"peak=\", format_bytes(estimate.estimated_peak_bytes),\n",
+        "        \"fits=\", estimate.fits_usable_memory,\n",
+        "    )\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 4 - Compare feature-node caps\n",
+        "\n",
+        "`max_feature_nodes` affects node count, but for very long prompts the error nodes from `layers * tokens` often dominate. Lowering the feature cap is still useful for exploratory runs.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for cap in [1000, 2500, 7500]:\n",
+        "    estimate = estimate_graph_memory(\n",
+        "        n_tokens=6000,\n",
+        "        n_layers=26,\n",
+        "        max_feature_nodes=cap,\n",
+        "        n_logits=10,\n",
+        "        dtype=\"float16\",\n",
+        "        available_memory_gib=80,\n",
+        "    )\n",
+        "    print(\n",
+        "        f\"cap={cap:>4}\",\n",
+        "        \"nodes=\", f\"{estimate.n_total_nodes:,}\",\n",
+        "        \"peak=\", format_bytes(estimate.estimated_peak_bytes),\n",
+        "        \"fits=\", estimate.fits_usable_memory,\n",
+        "    )\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## CLI equivalent\n",
+        "\n",
+        "The same estimate is available without Python code:\n",
+        "\n",
+        "```bash\n",
+        "circuit-tracer estimate-memory \\\n",
+        "  --tokens 6000 \\\n",
+        "  --layers 26 \\\n",
+        "  --max_feature_nodes 7500 \\\n",
+        "  --n_logits 10 \\\n",
+        "  --dtype float16 \\\n",
+        "  --available_memory_gib 80\n",
+        "```\n",
+        "\n",
+        "Use `--format json` when you want machine-readable output for scripts or dashboards.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Exercise\n",
+        "\n",
+        "Try a model with 32 layers and a 3,000-token prompt. Predict whether `float16` fits in a 48 GiB GPU after the default 80% safety margin, then run the next cell.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "exercise = estimate_graph_memory(\n",
+        "    n_tokens=3000,\n",
+        "    n_layers=32,\n",
+        "    max_feature_nodes=5000,\n",
+        "    n_logits=10,\n",
+        "    dtype=\"float16\",\n",
+        "    available_memory_gib=48,\n",
+        ")\n",
+        "\n",
+        "print(exercise.to_markdown())\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Common pitfall: pruning thresholds reduce the exported graph after dense tensors have already been built. If this estimator says the initial dense graph is too large, increasing pruning thresholds alone will not fix the allocation problem.\n",
+        "\n",
+        "Extension: use the estimator across a grid of token counts to choose a safe maximum prompt length for your hardware before running attribution.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/docs/long_context_memory_estimator.md
+++ b/docs/long_context_memory_estimator.md
@@ -1,0 +1,81 @@
+# Long-context memory estimator
+
+## Previous repository behavior
+
+Before this change, `circuit-tracer` could run attribution on long prompts, but it did not provide
+a cheap preflight estimate for the dense attribution-graph tensors created during graph construction
+and pruning. Users had to infer memory risk from model size, token count, and trial-and-error runs.
+That made long-context experiments especially expensive because the graph representation includes:
+
+- selected transcoder feature nodes,
+- one reconstruction-error node for every `(layer, token)` pair,
+- one token node per prompt token, and
+- one or more output-logit nodes.
+
+The dense adjacency matrix scales as `total_nodes ** 2`, so long prompts can become infeasible even
+on large GPUs before model weights, transcoders, allocator overhead, and frontend JSON export are
+considered.
+
+Baseline inspected for this work:
+
+- upstream repository: `decoderesearch/circuit-tracer`
+- local upstream commit: `eb0e0f9` (`Fix error node_id collision and misparse (issue #78) (#100)`)
+- existing CLI subcommands: `attribute`, `start-server`
+
+## What changed
+
+This branch adds a lightweight estimator that can be used without loading a model or downloading
+transcoders:
+
+- `circuit_tracer.utils.memory_estimation.estimate_graph_memory(...)`
+- `circuit_tracer.utils.estimate_graph_memory(...)`
+- `circuit-tracer estimate-memory ...`
+
+The estimator reports:
+
+- feature, error, token, logit, and total node counts,
+- dense adjacency tensor size,
+- dense boolean mask size,
+- approximate graph metadata tensor size,
+- conservative graph-pruning peak memory,
+- optional fit check against a user-provided memory budget, and
+- concrete recommendations for reducing OOM risk.
+
+The estimate intentionally focuses on graph memory, not full execution memory. It does not include
+model weights, transcoder weights, CUDA allocator fragmentation, tokenizer/model caches, notebook
+overhead, or browser/frontend memory.
+
+## Example
+
+```bash
+circuit-tracer estimate-memory \
+  --tokens 6000 \
+  --layers 26 \
+  --max_feature_nodes 7500 \
+  --n_logits 10 \
+  --dtype float16 \
+  --available_memory_gib 80
+```
+
+For this long-context configuration, the estimator shows that reconstruction-error nodes dominate
+the node count and that dense pruning memory can exceed an 80 GiB device budget after a safety
+margin. The practical result is that users can identify infeasible traces before spending time
+loading a model, transcoders, and activations.
+
+## Result of the change
+
+This is a quality and usability improvement, not a new attribution algorithm. It gives users an
+early answer to:
+
+- "Will this prompt length likely fit?"
+- "How much does dtype matter?"
+- "How much do feature-node caps matter?"
+- "Is this failure likely an inherent dense-graph scaling issue?"
+
+It also creates a clear foundation for future sparse or blockwise graph work: the estimator makes
+the dense scaling visible and quantifies when a sparse backend becomes necessary.
+
+## Demo notebook
+
+See `demos/long_context_memory_estimator_demo.ipynb` for an executable walkthrough that compares
+short and long prompt configurations and shows the CLI-equivalent Python API.

--- a/tests/utils/test_memory_estimation.py
+++ b/tests/utils/test_memory_estimation.py
@@ -1,0 +1,81 @@
+import pytest
+
+from circuit_tracer.utils.memory_estimation import estimate_graph_memory, format_bytes
+
+
+def test_estimate_graph_memory_node_counts_and_dense_bytes():
+    estimate = estimate_graph_memory(
+        n_tokens=100,
+        n_layers=4,
+        max_feature_nodes=50,
+        n_logits=5,
+        dtype="float32",
+    )
+
+    assert estimate.n_error_nodes == 400
+    assert estimate.n_token_nodes == 100
+    assert estimate.n_logit_nodes == 5
+    assert estimate.n_total_nodes == 555
+    assert estimate.dense_adjacency_bytes == 555 * 555 * 4
+    assert estimate.dense_bool_mask_bytes == 555 * 555
+    assert estimate.pruning_peak_bytes == 4 * estimate.dense_adjacency_bytes + 555 * 555
+
+
+def test_estimate_graph_memory_dtype_alias_halves_adjacency():
+    fp32 = estimate_graph_memory(n_tokens=128, n_layers=8, dtype="fp32")
+    bf16 = estimate_graph_memory(n_tokens=128, n_layers=8, dtype="bf16")
+
+    assert fp32.dtype == "float32"
+    assert bf16.dtype == "bfloat16"
+    assert fp32.bytes_per_value == 4
+    assert bf16.bytes_per_value == 2
+    assert bf16.dense_adjacency_bytes == fp32.dense_adjacency_bytes // 2
+
+
+def test_estimate_graph_memory_flags_h100_sized_long_context_risk():
+    estimate = estimate_graph_memory(
+        n_tokens=6000,
+        n_layers=26,
+        max_feature_nodes=7500,
+        n_logits=10,
+        dtype="float16",
+        available_memory_gib=80,
+    )
+
+    assert estimate.fits_usable_memory is False
+    assert estimate.n_error_nodes == 156_000
+    assert estimate.estimated_peak_bytes > estimate.usable_memory_bytes
+    assert any("exceeds the usable memory budget" in rec for rec in estimate.recommendations)
+    assert any("sparse or blockwise graph backend" in rec for rec in estimate.recommendations)
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"n_tokens": 0, "n_layers": 2}, "n_tokens must be positive"),
+        ({"n_tokens": 5, "n_layers": 0}, "n_layers must be positive"),
+        ({"n_tokens": 5, "n_layers": 2, "dtype": "int8"}, "Unsupported dtype"),
+        ({"n_tokens": 5, "n_layers": 2, "safety_fraction": 0}, "safety_fraction"),
+    ],
+)
+def test_estimate_graph_memory_validation(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        estimate_graph_memory(**kwargs)
+
+
+def test_estimate_graph_memory_serialization_helpers():
+    estimate = estimate_graph_memory(
+        n_tokens=16,
+        n_layers=2,
+        max_feature_nodes=8,
+        n_logits=2,
+        dtype="float16",
+        available_memory_gib=1,
+    )
+
+    as_dict = estimate.to_dict()
+    assert as_dict["nodes"]["total_nodes"] == 58
+    assert "estimated_peak" in as_dict["memory"]
+    assert "Recommendations" in estimate.to_markdown()
+    assert '"fits_usable_memory"' in estimate.to_json()
+    assert format_bytes(1024**3) == "1.00 GiB"


### PR DESCRIPTION
**Change** : Added a long-context memory estimator for attribution runs. It estimates graph node counts and dense graph memory before loading a model or transcoders.
**Example result** : For a 6000-token, 26-layer run on an 80 GiB GPU, the estimator warns that dense graph pruning may exceed usable memory, so users can reduce prompt length, feature nodes, logits, or dtype before running an expensive trace.