### PR TITLE
updating versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0"
+
 [tool.ruff]
 line-length = 100
 exclude = ["*.ipynb", "demos"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "circuit-tracer"
-version = "0.4.1"
+dynamic = ["version"]
 description = "Library for circuit tracing in language models"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -28,8 +28,11 @@ dev = ["pytest>=8.0.0", "ruff>=0.12.7", "pyright>=1.1.403", "ipython>=8.37.0"]
 circuit-tracer = "circuit_tracer.__main__:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Previously, versioning required not only creating a tag but also manually updating pyproject.toml. This should eliminate the need for the latter step.