### PR TITLE
Format Python code blocks in Markdown so CI's formatting check passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In order to use the `lazy_decoder` and `lazy_encoder` options on transcoders, th
 from circuit_tracer.utils.caching import save_transcoders_to_cache
 
 hf_ref = "mwhanna/gemma-scope-2-27b-pt/transcoder_all/width_262k_l0_small"
-cache_dir = '~/.cache/'
+cache_dir = "~/.cache/"
 save_transcoders_to_cache(hf_ref, cache_dir=cache_dir)
 ```
 

--- a/circuit_tracer/utils/MAPPING_INFO.md
+++ b/circuit_tracer/utils/MAPPING_INFO.md
@@ -12,7 +12,9 @@ class TransformerLens_NNSight_Mapping:
     embed_location: str  # Location of the embedding Module (the location to which we will attribute for embeddings)
     embed_weight: str  # Location of the embedding weight matrix
     unembed_weight: str  # Location of the unembedding weight matrix
-    feature_hook_mapping: dict[str, tuple[str, Literal['input', 'output']]]  # Mapping from (TransformerLens Hook) to a tuple representing an NNSight Envoy location, and whether we want its input or output
+    feature_hook_mapping: dict[
+        str, tuple[str, Literal["input", "output"]]
+    ]  # Mapping from (TransformerLens Hook) to a tuple representing an NNSight Envoy location, and whether we want its input or output
 ```
 
 The values of the location / pattern fields are the NNSight locations whose outputs we need to access or freeze. For example, if `embed_location="model.embed_tokens"`, this means that `model.model.embed_tokens` is the location of the embeddings, and `model.model.embed_tokens.output` will fetch its output.


### PR DESCRIPTION
`ruff format --check` currently fails on `main`. It is the first step of CI, so it gates linting,
type checking and the test suite for every open PR.

### Cause

ruff **0.16.0** (2026-07-23) began formatting Python code blocks inside Markdown files. The `dev`
extra declares `ruff>=0.12.7` with no upper bound, so CI installs a ruff that applies this. Bisected
against an unmodified checkout of `main` (`8f1e243`):

| ruff | `ruff format --check` |
| --- | --- |
| 0.12.7 (the declared floor) | 61 files, clean |
| 0.15.2 | 61 files, clean |
| 0.16.4 (current) | 65 files, **2 would be reformatted** |

`main`'s last green CI run was 2026-07-18, five days before 0.16.0, and `main` has not been pushed
since, so the break has never surfaced on `main` itself. It appears on PRs because CI builds
`refs/pull/N/merge` and inherits `main`'s files, which can make a red check look like the PR's fault
when the PR does not touch either file.

### Change

Reformats the two affected code blocks only: a quote style in `README.md` and a wrapped type
annotation in `circuit_tracer/utils/MAPPING_INFO.md`. No prose, no code semantics, no public surface.

### Relationship to #111

**This change already exists in #111**, whose `circuit_tracer/utils/MAPPING_INFO.md` is byte-identical
to what ruff produces here. That is why #111 is green while other PRs are red. This PR exists only so
the unblock is not coupled to a 30-file feature PR. If you would rather land it through #111, please
close this one: the effect is identical and nothing here is novel.

### Optional follow-up, not included

The recurrence risk is the unpinned floor rather than these two files: the next ruff formatting
feature will do this again. A ceiling (`ruff>=0.12.7,<0.17`) or a pinned dev version would prevent
that. Happy to add it here if you want it, or to leave the diff minimal.
@hannamw 
